### PR TITLE
Docker compose changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The website is now listening available on `http://localhost:3000`, have fun with
 With ClamAV the shares get scanned for malicious files and get removed if any found.
 
 1. Add the ClamAV container to the Docker Compose stack (see `docker-compose.yml`) and start the container.
-2. Docker will wait for ClamAV to start before starting pingvin-share.  This make take a minute or two.
+2. Docker will wait for ClamAV to start before starting Pingvin Share. This may take a minute or two.
 3. The Pingvin Share logs should now log "ClamAV is active"
 
 Please note that ClamAV needs a lot of [ressources](https://docs.clamav.net/manual/Installing/Docker.html#memory-ram-requirements).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The website is now listening available on `http://localhost:3000`, have fun with
 With ClamAV the shares get scanned for malicious files and get removed if any found.
 
 1. Add the ClamAV container to the Docker Compose stack (see `docker-compose.yml`) and start the container.
-2. As soon as the ClamAV container is ready (when ClamAV logs "socket found, clamd started"), restart the Pingvin Share container with `docker compose restart pingvin-share`
+2. Docker will wait for ClamAV to start before starting pingvin-share.  This make take a minute or two.
 3. The Pingvin Share logs should now log "ClamAV is active"
 
 Please note that ClamAV needs a lot of [ressources](https://docs.clamav.net/manual/Installing/Docker.html#memory-ram-requirements).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ services:
   pingvin-share:
     image: stonith404/pingvin-share
     restart: unless-stopped
+# Optional: If you add clamav, uncomment the following to have clamav start first.
+#    depends_on:
+#      clamav:
+#        condition: service_healthy
     ports:
       - 3000:3000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,14 @@ services:
   pingvin-share:
     image: stonith404/pingvin-share
     restart: unless-stopped
-# Optional: If you add clamav, uncomment the following to have clamav start first.
-#    depends_on:
-#      clamav:
-#        condition: service_healthy
     ports:
       - 3000:3000
     volumes:
       - "./data:/opt/app/backend/data"
+# Optional: If you add ClamAV, uncomment the following to have ClamAV start first.
+#    depends_on:
+#      clamav:
+#        condition: service_healthy
 # Optional: Add ClamAV (see README.md)  
 # ClamAV is currently only available for AMD64 see https://github.com/Cisco-Talos/clamav/issues/482
 #  clamav:


### PR DESCRIPTION
Instead of having the user restart pingvin-share after clamav is ready, this has the pingvin-share container not start until clamav has reported that it has fully started.

The README was changed as well.