### PR TITLE
feat: Adding more informations on My Shares page (table and modal)

### DIFF
--- a/backend/src/share/dto/myShare.dto.ts
+++ b/backend/src/share/dto/myShare.dto.ts
@@ -1,7 +1,13 @@
-import { Expose, plainToClass } from "class-transformer";
+import { Expose, plainToClass, Type } from "class-transformer";
 import { ShareDTO } from "./share.dto";
+import {FileDTO} from "../../file/dto/file.dto";
+import {OmitType} from "@nestjs/swagger";
 
-export class MyShareDTO extends ShareDTO {
+export class MyShareDTO extends OmitType(ShareDTO, [
+  "files",
+  "from",
+  "fromList",
+] as const) {
   @Expose()
   views: number;
 
@@ -10,6 +16,10 @@ export class MyShareDTO extends ShareDTO {
 
   @Expose()
   recipients: string[];
+
+  @Expose()
+  @Type(() => OmitType(FileDTO, ["share", "from"] as const))
+  files: Omit<FileDTO, "share" | "from">[];
 
   from(partial: Partial<MyShareDTO>) {
     return plainToClass(MyShareDTO, partial, { excludeExtraneousValues: true });

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -195,7 +195,7 @@ export class ShareService {
       orderBy: {
         expiration: "desc",
       },
-      include: { recipients: true },
+      include: { recipients: true, files: true },
     });
 
     return shares.map((share) => {

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -10,7 +10,7 @@ const showShareInformationsModal = (
   modals: ModalsContextProps,
   share: MyShare,
   appUrl: string,
-  maxShareSize: number | string
+  maxShareSize: number
 ) => {
   const link = `${appUrl}/share/${share.id}`;
 

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -21,7 +21,7 @@ const showShareInformationsModal = (
 
   const formattedShareSize = byteToHumanSizeString(shareSize);
   const formattedMaxShareSize = byteToHumanSizeString(maxShareSize);
-  const shareProgress = (shareSize / maxShareSize) * 100;
+  const shareSizeProgress = (shareSize / maxShareSize) * 100;
 
   const formattedCreatedAt = moment(share.createdAt).format("LLL");
   const formattedExpiration =

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -1,4 +1,4 @@
-import {Text, Divider, Progress, Stack, Group} from '@mantine/core';
+import {Text, Divider, Progress, Stack, Group, Flex} from '@mantine/core';
 import { ModalsContextProps } from "@mantine/modals/lib/context";
 import { MyShare } from "../../types/share.type";
 import moment from "moment";
@@ -12,7 +12,7 @@ const showShareInformationsModal = (
   maxShareSize: number | string
 ) => {
   const link = `${appUrl}/share/${share.id}`;
-  const shareSize = 165564769; // TODO: get share size from backend
+  const shareSize = 565564769; // TODO: get share size from backend
   if (typeof maxShareSize === "string") {
     maxShareSize = parseInt(maxShareSize);
   }
@@ -21,46 +21,62 @@ const showShareInformationsModal = (
 
     children: (
       <Stack align="stretch">
-          <Text size="sm" color="lightgray" style={{ margin: '0.5rem 0' }}>
-            <b>ID:</b> {share.id}
-          </Text>
+        <Text size="sm" color="lightgray" style={{ margin: '0.5rem 0' }}>
+          <b>ID:</b> {share.id}
+        </Text>
 
-          <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
-            <b>Creator :</b> You
-          </Text>
+        <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
+          <b>Creator :</b> You
+        </Text>
 
-          <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
-            <b>Created at :</b> {moment(share.createdAt).format("LLL")}
-          </Text>
+        <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
+          <b>Description :</b> {share.description || "No description"}
+        </Text>
 
-          <Text size="sm" color="lightgray">
-            <b>Expires at :</b> {moment(share.expiration).format("LLL")}
-          </Text>
+        <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
+          <b>Created at :</b> {moment(share.createdAt).format("LLL")}
+        </Text>
 
-          <Divider style={{ margin: '.5rem 0' }} />
+        <Text size="sm" color="lightgray">
+          <b>Expires at :</b> {moment(share.expiration).format("LLL")}
+        </Text>
 
-          <CopyTextField link={link} />
+        <Divider style={{ margin: '.5rem 0' }} />
 
-          <Divider style={{ margin: '1rem 0' }} />
+        <CopyTextField link={link} />
 
-          <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
+        <Divider style={{ margin: '1rem 0' }} />
+
+        <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
+          <span>
             <b>Size :</b> {byteToHumanSizeString(shareSize)} / {byteToHumanSizeString(maxShareSize)}
+          </span>
+
+          { /* Faire un flex pour aligner le Progress et le text à droite */}
+
+          <Flex justify="center" direction={{base: 'row'}} align="center" style={{alignItems: "center", marginTop: "1rem"}}>
+            { (shareSize / maxShareSize < 0.1) && (
+              <Text size="xs" color="lightgray" style={{ marginRight: '4px'}}>
+                {byteToHumanSizeString(shareSize)}
+              </Text>
+            ) }
             <Progress
               value={((shareSize / maxShareSize) * 100)}
-              label={byteToHumanSizeString(shareSize)}
+              label={(shareSize / maxShareSize >= 0.1) ? (byteToHumanSizeString(shareSize)) : ""}
               color="blue"
-              style={{ marginTop: '0.5rem' }}
+              style={{ width: (shareSize / maxShareSize < 0.1) ? '70%' : '80%' }}
               size="xl"
               radius="xl"
-            >
-              <Group
-                position="right">
-                <Text size="sm" color="lightgray" style={{ marginRight: '0.5rem' }}>
-                  {byteToHumanSizeString(maxShareSize)}
-                </Text>
-              </Group>
-            </Progress>
-          </Text>
+
+            />
+            <Text size="xs" color="lightgray" style={{ marginLeft: '4px'}}>
+              {byteToHumanSizeString(maxShareSize)}
+            </Text>
+          </Flex>
+
+
+
+        </Text>
 
       </Stack>
     ),

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -32,7 +32,7 @@ const showShareInformationsModal = (
     title: "Share informations",
 
     children: (
-      <Stack align="stretch" spacing="xs">
+      <Stack align="stretch" spacing="md">
         <Text size="sm" color="lightgray">
           <b>ID:</b> {share.id}
         </Text>
@@ -59,29 +59,28 @@ const showShareInformationsModal = (
 
         <Divider />
 
-        <Flex align="center" justify="space-between" style={{ marginTop: "1rem" }}>
-          <Text size="sm" color="lightgray">
-            <b>Size:</b> {formattedShareSize} / {formattedMaxShareSize} ({(shareProgress.toFixed(1))}%)
-          </Text>
+        <Text size="sm" color="lightgray">
+          <b>Size:</b> {formattedShareSize} / {formattedMaxShareSize} ({(shareProgress.toFixed(1))}%)
+        </Text>
 
-          <Flex align="center">
-            {shareSize / maxShareSize < 0.1 && (
-              <Text size="xs" color="lightgray" style={{ marginRight: '4px' }}>
-                {formattedShareSize}
-              </Text>
-            )}
-            <Progress
-              value={shareProgress}
-              label={shareSize / maxShareSize >= 0.1 ? formattedShareSize : ""}
-              color="blue"
-              style={{ width: shareSize / maxShareSize < 0.1 ? '70%' : '80%' }}
-              size="xl"
-              radius="xl"
-            />
-            <Text size="xs" color="lightgray" style={{ marginLeft: '4px' }}>
-              {formattedMaxShareSize}
+        <Flex align="center" justify="center">
+          {shareSize / maxShareSize < 0.1 && (
+            <Text size="xs" color="lightgray" style={{ marginRight: '4px' }}>
+              {formattedShareSize}
             </Text>
-          </Flex>
+          )}
+          <Progress
+            value={shareProgress}
+            label={shareSize / maxShareSize >= 0.1 ? formattedShareSize : ""}
+
+            color="blue"
+            style={{ width: shareSize / maxShareSize < 0.1 ? '70%' : '80%' }}
+            size="xl"
+            radius="xl"
+          />
+          <Text size="xs" color="lightgray" style={{ marginLeft: '4px' }}>
+            {formattedMaxShareSize}
+          </Text>
         </Flex>
       </Stack>
     ),

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -1,0 +1,49 @@
+import { Stack, TextInput } from "@mantine/core";
+import { Text, Badge, Divider } from '@mantine/core';
+import { ModalsContextProps } from "@mantine/modals/lib/context";
+import { MyShare } from "../../types/share.type";
+import moment from "moment";
+import {byteToHumanSizeString} from "../../utils/fileSize.util";
+
+const showShareInformationsModal = (
+  modals: ModalsContextProps,
+  share: MyShare,
+  appUrl: string
+) => {
+  const link = `${appUrl}/share/${share.id}`;
+  console.log(share)
+  console.log(share.files)
+  return modals.openModal({
+    title: "Share informations",
+    children: (
+      <Stack align="stretch">
+          <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
+            ID: {share.id}
+          </Text>
+
+          <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
+            Author: N/A
+          </Text>
+
+          <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
+            Created at: {moment(share.createdAt).format("LLL")}
+          </Text>
+
+          <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
+            Expires at: {moment(share.expiration).format("LLL")}
+          </Text>
+
+          <Divider style={{ margin: '1rem 0' }} />
+
+          <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
+
+          </Text>
+
+          <Divider style={{ margin: '1rem 0' }} />
+
+      </Stack>
+    ),
+  });
+};
+
+export default showShareInformationsModal;

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -38,7 +38,9 @@ const showShareInformationsModal = (
         </Text>
 
         <Text size="sm" color="lightgray">
-          <b>Expires at :</b> {moment(share.expiration).format("LLL")}
+          <b>Expires at :</b> {moment(share.expiration).unix() === 0
+                                          ? "Never"
+                                          : moment(share.expiration).format("LLL")}
         </Text>
 
         <Divider style={{ margin: '.5rem 0' }} />

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -18,7 +18,6 @@ const showShareInformationsModal = (
   for (let file of share.files as FileMetaData[])
     shareSize += parseInt(file.size);
 
-
   const formattedShareSize = byteToHumanSizeString(shareSize);
   const formattedMaxShareSize = byteToHumanSizeString(maxShareSize);
   const shareSizeProgress = (shareSize / maxShareSize) * 100;

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -1,10 +1,10 @@
-import {Text, Divider, Progress, Stack, Group, Flex} from '@mantine/core';
+import { Text, Divider, Progress, Stack, Group, Flex } from "@mantine/core";
 import { ModalsContextProps } from "@mantine/modals/lib/context";
 import { MyShare } from "../../types/share.type";
 import moment from "moment";
-import {byteToHumanSizeString} from "../../utils/fileSize.util";
+import { byteToHumanSizeString } from "../../utils/fileSize.util";
 import CopyTextField from "../upload/CopyTextField";
-import { FileMetaData} from "../../types/File.type";
+import { FileMetaData } from "../../types/File.type";
 
 const showShareInformationsModal = (
   modals: ModalsContextProps,
@@ -12,11 +12,11 @@ const showShareInformationsModal = (
   appUrl: string,
   maxShareSize: number | string
 ) => {
-
   const link = `${appUrl}/share/${share.id}`;
 
   let shareSize: number = 0;
-  for(let file of (share.files) as FileMetaData[]) shareSize += parseInt(file.size);
+  for (let file of share.files as FileMetaData[])
+    shareSize += parseInt(file.size);
 
   if (typeof maxShareSize === "string") maxShareSize = parseInt(maxShareSize);
 
@@ -25,8 +25,10 @@ const showShareInformationsModal = (
   const shareProgress = (shareSize / maxShareSize) * 100;
 
   const formattedCreatedAt = moment(share.createdAt).format("LLL");
-  const formattedExpiration = moment(share.expiration).unix() === 0 ? "Never"
-    : moment(share.expiration).format("LLL");
+  const formattedExpiration =
+    moment(share.expiration).unix() === 0
+      ? "Never"
+      : moment(share.expiration).format("LLL");
 
   return modals.openModal({
     title: "Share informations",
@@ -60,25 +62,25 @@ const showShareInformationsModal = (
         <Divider />
 
         <Text size="sm" color="lightgray">
-          <b>Size:</b> {formattedShareSize} / {formattedMaxShareSize} ({(shareProgress.toFixed(1))}%)
+          <b>Size:</b> {formattedShareSize} / {formattedMaxShareSize} (
+          {shareProgress.toFixed(1)}%)
         </Text>
 
         <Flex align="center" justify="center">
           {shareSize / maxShareSize < 0.1 && (
-            <Text size="xs" color="lightgray" style={{ marginRight: '4px' }}>
+            <Text size="xs" color="lightgray" style={{ marginRight: "4px" }}>
               {formattedShareSize}
             </Text>
           )}
           <Progress
             value={shareProgress}
             label={shareSize / maxShareSize >= 0.1 ? formattedShareSize : ""}
-
             color="blue"
-            style={{ width: shareSize / maxShareSize < 0.1 ? '70%' : '80%' }}
+            style={{ width: shareSize / maxShareSize < 0.1 ? "70%" : "80%" }}
             size="xl"
             radius="xl"
           />
-          <Text size="xs" color="lightgray" style={{ marginLeft: '4px' }}>
+          <Text size="xs" color="lightgray" style={{ marginLeft: "4px" }}>
             {formattedMaxShareSize}
           </Text>
         </Flex>

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -4,6 +4,7 @@ import { MyShare } from "../../types/share.type";
 import moment from "moment";
 import {byteToHumanSizeString} from "../../utils/fileSize.util";
 import CopyTextField from "../upload/CopyTextField";
+import { FileMetaData} from "../../types/File.type";
 
 const showShareInformationsModal = (
   modals: ModalsContextProps,
@@ -11,75 +12,77 @@ const showShareInformationsModal = (
   appUrl: string,
   maxShareSize: number | string
 ) => {
+
   const link = `${appUrl}/share/${share.id}`;
-  const shareSize = 565564769; // TODO: get share size from backend
-  if (typeof maxShareSize === "string") {
-    maxShareSize = parseInt(maxShareSize);
-  }
+
+  let shareSize: number = 0;
+  for(let file of (share.files) as FileMetaData[]) shareSize += parseInt(file.size);
+
+  if (typeof maxShareSize === "string") maxShareSize = parseInt(maxShareSize);
+
+  const formattedShareSize = byteToHumanSizeString(shareSize);
+  const formattedMaxShareSize = byteToHumanSizeString(maxShareSize);
+  const shareProgress = (shareSize / maxShareSize) * 100;
+
+  const formattedCreatedAt = moment(share.createdAt).format("LLL");
+  const formattedExpiration = moment(share.expiration).unix() === 0 ? "Never"
+    : moment(share.expiration).format("LLL");
+
   return modals.openModal({
     title: "Share informations",
 
     children: (
-      <Stack align="stretch">
-        <Text size="sm" color="lightgray" style={{ margin: '0.5rem 0' }}>
+      <Stack align="stretch" spacing="xs">
+        <Text size="sm" color="lightgray">
           <b>ID:</b> {share.id}
         </Text>
 
-        <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
-          <b>Creator :</b> You
-        </Text>
-
-        <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
-          <b>Description :</b> {share.description || "No description"}
-        </Text>
-
-        <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
-          <b>Created at :</b> {moment(share.createdAt).format("LLL")}
+        <Text size="sm" color="lightgray">
+          <b>Creator:</b> You
         </Text>
 
         <Text size="sm" color="lightgray">
-          <b>Expires at :</b> {moment(share.expiration).unix() === 0
-                                          ? "Never"
-                                          : moment(share.expiration).format("LLL")}
+          <b>Description:</b> {share.description || "No description"}
         </Text>
 
-        <Divider style={{ margin: '.5rem 0' }} />
+        <Text size="sm" color="lightgray">
+          <b>Created at:</b> {formattedCreatedAt}
+        </Text>
+
+        <Text size="sm" color="lightgray">
+          <b>Expires at:</b> {formattedExpiration}
+        </Text>
+
+        <Divider />
 
         <CopyTextField link={link} />
 
-        <Divider style={{ margin: '1rem 0' }} />
+        <Divider />
 
-        <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
-          <span>
-            <b>Size :</b> {byteToHumanSizeString(shareSize)} / {byteToHumanSizeString(maxShareSize)}
-          </span>
+        <Flex align="center" justify="space-between" style={{ marginTop: "1rem" }}>
+          <Text size="sm" color="lightgray">
+            <b>Size:</b> {formattedShareSize} / {formattedMaxShareSize} ({(shareProgress.toFixed(1))}%)
+          </Text>
 
-          { /* Faire un flex pour aligner le Progress et le text à droite */}
-
-          <Flex justify="center" direction={{base: 'row'}} align="center" style={{alignItems: "center", marginTop: "1rem"}}>
-            { (shareSize / maxShareSize < 0.1) && (
-              <Text size="xs" color="lightgray" style={{ marginRight: '4px'}}>
-                {byteToHumanSizeString(shareSize)}
+          <Flex align="center">
+            {shareSize / maxShareSize < 0.1 && (
+              <Text size="xs" color="lightgray" style={{ marginRight: '4px' }}>
+                {formattedShareSize}
               </Text>
-            ) }
+            )}
             <Progress
-              value={((shareSize / maxShareSize) * 100)}
-              label={(shareSize / maxShareSize >= 0.1) ? (byteToHumanSizeString(shareSize)) : ""}
+              value={shareProgress}
+              label={shareSize / maxShareSize >= 0.1 ? formattedShareSize : ""}
               color="blue"
-              style={{ width: (shareSize / maxShareSize < 0.1) ? '70%' : '80%' }}
+              style={{ width: shareSize / maxShareSize < 0.1 ? '70%' : '80%' }}
               size="xl"
               radius="xl"
-
             />
-            <Text size="xs" color="lightgray" style={{ marginLeft: '4px'}}>
-              {byteToHumanSizeString(maxShareSize)}
+            <Text size="xs" color="lightgray" style={{ marginLeft: '4px' }}>
+              {formattedMaxShareSize}
             </Text>
           </Flex>
-
-
-
-        </Text>
-
+        </Flex>
       </Stack>
     ),
   });

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -1,45 +1,66 @@
-import { Stack, TextInput } from "@mantine/core";
-import { Text, Badge, Divider } from '@mantine/core';
+import {Text, Divider, Progress, Stack, Group} from '@mantine/core';
 import { ModalsContextProps } from "@mantine/modals/lib/context";
 import { MyShare } from "../../types/share.type";
 import moment from "moment";
 import {byteToHumanSizeString} from "../../utils/fileSize.util";
+import CopyTextField from "../upload/CopyTextField";
 
 const showShareInformationsModal = (
   modals: ModalsContextProps,
   share: MyShare,
-  appUrl: string
+  appUrl: string,
+  maxShareSize: number | string
 ) => {
   const link = `${appUrl}/share/${share.id}`;
-  console.log(share)
-  console.log(share.files)
+  const shareSize = 165564769; // TODO: get share size from backend
+  if (typeof maxShareSize === "string") {
+    maxShareSize = parseInt(maxShareSize);
+  }
   return modals.openModal({
     title: "Share informations",
+
     children: (
       <Stack align="stretch">
-          <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
-            ID: {share.id}
+          <Text size="sm" color="lightgray" style={{ margin: '0.5rem 0' }}>
+            <b>ID:</b> {share.id}
           </Text>
 
           <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
-            Author: N/A
+            <b>Creator :</b> You
           </Text>
 
           <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
-            Created at: {moment(share.createdAt).format("LLL")}
+            <b>Created at :</b> {moment(share.createdAt).format("LLL")}
           </Text>
 
-          <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
-            Expires at: {moment(share.expiration).format("LLL")}
+          <Text size="sm" color="lightgray">
+            <b>Expires at :</b> {moment(share.expiration).format("LLL")}
           </Text>
+
+          <Divider style={{ margin: '.5rem 0' }} />
+
+          <CopyTextField link={link} />
 
           <Divider style={{ margin: '1rem 0' }} />
 
           <Text size="sm" color="lightgray" style={{ marginBottom: '0.5rem' }}>
-
+            <b>Size :</b> {byteToHumanSizeString(shareSize)} / {byteToHumanSizeString(maxShareSize)}
+            <Progress
+              value={((shareSize / maxShareSize) * 100)}
+              label={byteToHumanSizeString(shareSize)}
+              color="blue"
+              style={{ marginTop: '0.5rem' }}
+              size="xl"
+              radius="xl"
+            >
+              <Group
+                position="right">
+                <Text size="sm" color="lightgray" style={{ marginRight: '0.5rem' }}>
+                  {byteToHumanSizeString(maxShareSize)}
+                </Text>
+              </Group>
+            </Progress>
           </Text>
-
-          <Divider style={{ margin: '1rem 0' }} />
 
       </Stack>
     ),

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -39,10 +39,6 @@ const showShareInformationsModal = (
         </Text>
 
         <Text size="sm" color="lightgray">
-          <b>Creator:</b> You
-        </Text>
-
-        <Text size="sm" color="lightgray">
           <b>Description:</b> {share.description || "No description"}
         </Text>
 
@@ -62,7 +58,7 @@ const showShareInformationsModal = (
 
         <Text size="sm" color="lightgray">
           <b>Size:</b> {formattedShareSize} / {formattedMaxShareSize} (
-          {shareProgress.toFixed(1)}%)
+          {shareSizeProgress.toFixed(1)}%)
         </Text>
 
         <Flex align="center" justify="center">
@@ -72,7 +68,7 @@ const showShareInformationsModal = (
             </Text>
           )}
           <Progress
-            value={shareProgress}
+            value={shareSizeProgress}
             label={shareSize / maxShareSize >= 0.1 ? formattedShareSize : ""}
             style={{ width: shareSize / maxShareSize < 0.1 ? "70%" : "80%" }}
             size="xl"

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -18,7 +18,6 @@ const showShareInformationsModal = (
   for (let file of share.files as FileMetaData[])
     shareSize += parseInt(file.size);
 
-  if (typeof maxShareSize === "string") maxShareSize = parseInt(maxShareSize);
 
   const formattedShareSize = byteToHumanSizeString(shareSize);
   const formattedMaxShareSize = byteToHumanSizeString(maxShareSize);

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -74,7 +74,6 @@ const showShareInformationsModal = (
           <Progress
             value={shareProgress}
             label={shareSize / maxShareSize >= 0.1 ? formattedShareSize : ""}
-            color="blue"
             style={{ width: shareSize / maxShareSize < 0.1 ? "70%" : "80%" }}
             size="xl"
             radius="xl"

--- a/frontend/src/pages/account/shares.tsx
+++ b/frontend/src/pages/account/shares.tsx
@@ -71,7 +71,16 @@ const MyShares = () => {
               {shares.map((share) => (
                 <tr key={share.id}>
                   <td>{share.id}</td>
-                  <td>{share.description || ""}</td>
+                  <td
+                    style={{
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      maxWidth: "300px",
+                    }}
+                  >
+                    {share.description || ""}
+                  </td>
                   <td>{share.views}</td>
                   <td>
                     {moment(share.expiration).unix() === 0

--- a/frontend/src/pages/account/shares.tsx
+++ b/frontend/src/pages/account/shares.tsx
@@ -15,7 +15,7 @@ import { useModals } from "@mantine/modals";
 import moment from "moment";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { TbLink, TbTrash } from "react-icons/tb";
+import { TbLink, TbTrash, TbInfoCircle } from "react-icons/tb";
 import showShareLinkModal from "../../components/account/showShareLinkModal";
 import CenterLoader from "../../components/core/CenterLoader";
 import Meta from "../../components/Meta";
@@ -23,6 +23,7 @@ import useConfig from "../../hooks/config.hook";
 import shareService from "../../services/share.service";
 import { MyShare } from "../../types/share.type";
 import toast from "../../utils/toast.util";
+import showShareInformationsModal from "../../components/account/showShareInformationsModal";
 
 const MyShares = () => {
   const modals = useModals();
@@ -36,6 +37,8 @@ const MyShares = () => {
   }, []);
 
   if (!shares) return <CenterLoader />;
+
+  console.log(shares);
 
   return (
     <>
@@ -77,6 +80,20 @@ const MyShares = () => {
                   </td>
                   <td>
                     <Group position="right">
+                      <ActionIcon
+                        color="blue"
+                        variant="light"
+                        size={25}
+                        onClick={() => {
+                          showShareInformationsModal(
+                            modals,
+                            share,
+                            config.get("general.appUrl")
+                          );
+                        }}
+                      >
+                        <TbInfoCircle />
+                      </ActionIcon>
                       <ActionIcon
                         color="victoria"
                         variant="light"

--- a/frontend/src/pages/account/shares.tsx
+++ b/frontend/src/pages/account/shares.tsx
@@ -38,8 +38,6 @@ const MyShares = () => {
 
   if (!shares) return <CenterLoader />;
 
-  console.log(shares);
-
   return (
     <>
       <Meta title="My shares" />

--- a/frontend/src/pages/account/shares.tsx
+++ b/frontend/src/pages/account/shares.tsx
@@ -89,7 +89,7 @@ const MyShares = () => {
                             modals,
                             share,
                             config.get("general.appUrl"),
-                            config.get("share.maxSize")
+                            parseInt(config.get("share.maxSize"))
                           );
                         }}
                       >

--- a/frontend/src/pages/account/shares.tsx
+++ b/frontend/src/pages/account/shares.tsx
@@ -61,6 +61,7 @@ const MyShares = () => {
             <thead>
               <tr>
                 <th>Name</th>
+                <th>Description</th>
                 <th>Visitors</th>
                 <th>Expires at</th>
                 <th></th>
@@ -70,6 +71,7 @@ const MyShares = () => {
               {shares.map((share) => (
                 <tr key={share.id}>
                   <td>{share.id}</td>
+                  <td>{share.description || ""}</td>
                   <td>{share.views}</td>
                   <td>
                     {moment(share.expiration).unix() === 0

--- a/frontend/src/pages/account/shares.tsx
+++ b/frontend/src/pages/account/shares.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Center,
   Group,
+  MediaQuery,
   Space,
   Stack,
   Table,
@@ -61,7 +62,10 @@ const MyShares = () => {
             <thead>
               <tr>
                 <th>Name</th>
-                <th>Description</th>
+                <MediaQuery smallerThan="md" styles={{ display: "none" }}>
+                  <th>Description</th>
+                </MediaQuery>
+
                 <th>Visitors</th>
                 <th>Expires at</th>
                 <th></th>
@@ -71,16 +75,18 @@ const MyShares = () => {
               {shares.map((share) => (
                 <tr key={share.id}>
                   <td>{share.id}</td>
-                  <td
-                    style={{
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                      maxWidth: "300px",
-                    }}
-                  >
-                    {share.description || ""}
-                  </td>
+                  <MediaQuery smallerThan="sm" styles={{ display: "none" }}>
+                    <td
+                      style={{
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        maxWidth: "300px",
+                      }}
+                    >
+                      {share.description || ""}
+                    </td>
+                  </MediaQuery>
                   <td>{share.views}</td>
                   <td>
                     {moment(share.expiration).unix() === 0

--- a/frontend/src/pages/account/shares.tsx
+++ b/frontend/src/pages/account/shares.tsx
@@ -88,7 +88,8 @@ const MyShares = () => {
                           showShareInformationsModal(
                             modals,
                             share,
-                            config.get("general.appUrl")
+                            config.get("general.appUrl"),
+                            config.get("share.maxSize")
                           );
                         }}
                       >

--- a/frontend/src/types/share.type.ts
+++ b/frontend/src/types/share.type.ts
@@ -24,7 +24,7 @@ export type ShareMetaData = {
 
 export type MyShare = Share & {
   views: number;
-  cratedAt: Date;
+  createdAt: Date;
 };
 
 export type MyReverseShare = {


### PR DESCRIPTION
The description of the share is now displayed out on the table of My Shares page and by clicking the new button Information, a Modal pops out, on which you can see multiples informations about the share, as shown below.

This Pull Request is related to the Issue #164 . Do not hesitate if you have any other ideas to add on the page, or if you want to modify these changes.

Images : 

![image](https://github.com/stonith404/pingvin-share/assets/83456236/6203f972-d68a-41a3-bb57-122e7e13fd6b)
![image](https://github.com/stonith404/pingvin-share/assets/83456236/d928b5fe-c5bf-42a4-af8c-1de97338e1d5)
