### PR TITLE
feat: Adding reverse share ability to copy the link

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -1,5 +1,9 @@
 export const DATA_DIRECTORY = process.env.DATA_DIRECTORY || "./data";
-export const SHARE_DIRECTORY =  `${DATA_DIRECTORY}/uploads/shares` 
-export const DATABASE_URL = process.env.DATABASE_URL || "file:../data/pingvin-share.db?connection_limit=1";
-export const CLAMAV_HOST = process.env.CLAMAV_HOST || (process.env.NODE_ENV == "docker" ? "clamav" : "127.0.0.1");
+export const SHARE_DIRECTORY = `${DATA_DIRECTORY}/uploads/shares`;
+export const DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "file:../data/pingvin-share.db?connection_limit=1";
+export const CLAMAV_HOST =
+  process.env.CLAMAV_HOST ||
+  (process.env.NODE_ENV == "docker" ? "clamav" : "127.0.0.1");
 export const CLAMAV_PORT = parseInt(process.env.CLAMAV_PORT) || 3310;

--- a/backend/src/reverseShare/dto/reverseShare.dto.ts
+++ b/backend/src/reverseShare/dto/reverseShare.dto.ts
@@ -10,6 +10,9 @@ export class ReverseShareDTO {
   @Expose()
   shareExpiration: Date;
 
+  @Expose()
+  token: string;
+
   from(partial: Partial<ReverseShareDTO>) {
     return plainToClass(ReverseShareDTO, partial, {
       excludeExtraneousValues: true,

--- a/backend/src/share/dto/myShare.dto.ts
+++ b/backend/src/share/dto/myShare.dto.ts
@@ -1,7 +1,7 @@
 import { Expose, plainToClass, Type } from "class-transformer";
 import { ShareDTO } from "./share.dto";
-import {FileDTO} from "../../file/dto/file.dto";
-import {OmitType} from "@nestjs/swagger";
+import { FileDTO } from "../../file/dto/file.dto";
+import { OmitType } from "@nestjs/swagger";
 
 export class MyShareDTO extends OmitType(ShareDTO, [
   "files",

--- a/frontend/src/components/account/showReverseShareLinkModal.tsx
+++ b/frontend/src/components/account/showReverseShareLinkModal.tsx
@@ -1,0 +1,20 @@
+import { Stack, TextInput } from "@mantine/core";
+import { ModalsContextProps } from "@mantine/modals/lib/context";
+
+const showReverseShareLinkModal = (
+  modals: ModalsContextProps,
+  reverseShareToken: string,
+  appUrl: string
+) => {
+  const link = `${appUrl}/upload/${reverseShareToken}`;
+  return modals.openModal({
+    title: "Reverse share link",
+    children: (
+      <Stack align="stretch">
+        <TextInput variant="filled" value={link} />
+      </Stack>
+    ),
+  });
+};
+
+export default showReverseShareLinkModal;

--- a/frontend/src/components/upload/CopyTextField.tsx
+++ b/frontend/src/components/upload/CopyTextField.tsx
@@ -1,8 +1,8 @@
-import { useRef, useState } from "react";
-import toast from "../../utils/toast.util";
 import { ActionIcon, TextInput } from "@mantine/core";
-import { TbCheck, TbCopy } from "react-icons/tb";
 import { useClipboard } from "@mantine/hooks";
+import { useRef, useState } from "react";
+import { TbCheck, TbCopy } from "react-icons/tb";
+import toast from "../../utils/toast.util";
 
 function CopyTextField(props: { link: string }) {
   const clipboard = useClipboard({ timeout: 500 });
@@ -14,7 +14,7 @@ function CopyTextField(props: { link: string }) {
 
   const copyLink = () => {
     clipboard.copy(props.link);
-    toast.success("Your link was copied to the keyboard.");
+    toast.success("The link was copied to your clipboard.");
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
       setCheckState(false);

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -21,6 +21,7 @@ import showShareLinkModal from "../../components/account/showShareLinkModal";
 import CenterLoader from "../../components/core/CenterLoader";
 import Meta from "../../components/Meta";
 import showCreateReverseShareModal from "../../components/share/modals/showCreateReverseShareModal";
+import showReverseShareLinkModal from "../../components/account/showReverseShareLinkModal";
 import useConfig from "../../hooks/config.hook";
 import shareService from "../../services/share.service";
 import { MyReverseShare } from "../../types/share.type";
@@ -46,6 +47,8 @@ const MyShares = () => {
   useEffect(() => {
     getReverseShares();
   }, []);
+
+  console.log(reverseShares);
 
   if (!reverseShares) return <CenterLoader />;
   return (
@@ -168,6 +171,31 @@ const MyShares = () => {
                   </td>
                   <td>
                     <Group position="right">
+                    <ActionIcon
+                        color="victoria"
+                        variant="light"
+                        size={25}
+                        onClick={() => {
+                          if (window.isSecureContext) {
+                            clipboard.copy(
+                              `${config.get("general.appUrl")}/upload/${
+                                reverseShare.token
+                              }`
+                            );
+                            toast.success(
+                              "Your link was copied to the keyboard."
+                            );
+                          } else {
+                            showReverseShareLinkModal(
+                              modals,
+                              reverseShare.token,
+                              config.get("general.appUrl")
+                            );
+                          }
+                        }}
+                      >
+                        <TbLink />
+                      </ActionIcon>
                       <ActionIcon
                         color="red"
                         variant="light"

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -17,11 +17,11 @@ import { useModals } from "@mantine/modals";
 import moment from "moment";
 import { useEffect, useState } from "react";
 import { TbInfoCircle, TbLink, TbPlus, TbTrash } from "react-icons/tb";
+import Meta from "../../components/Meta";
+import showReverseShareLinkModal from "../../components/account/showReverseShareLinkModal";
 import showShareLinkModal from "../../components/account/showShareLinkModal";
 import CenterLoader from "../../components/core/CenterLoader";
-import Meta from "../../components/Meta";
 import showCreateReverseShareModal from "../../components/share/modals/showCreateReverseShareModal";
-import showReverseShareLinkModal from "../../components/account/showReverseShareLinkModal";
 import useConfig from "../../hooks/config.hook";
 import shareService from "../../services/share.service";
 import { MyReverseShare } from "../../types/share.type";
@@ -181,7 +181,7 @@ const MyShares = () => {
                               }`
                             );
                             toast.success(
-                              "Your link was copied to the keyboard."
+                              "The link was copied to your clipboard."
                             );
                           } else {
                             showReverseShareLinkModal(

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -169,7 +169,7 @@ const MyShares = () => {
                   </td>
                   <td>
                     <Group position="right">
-                    <ActionIcon
+                      <ActionIcon
                         color="victoria"
                         variant="light"
                         size={25}

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -39,8 +39,8 @@ const MyShares = () => {
 
   const getReverseShares = () => {
     shareService
-        .getMyReverseShares()
-        .then((shares) => setReverseShares(shares));
+      .getMyReverseShares()
+      .then((shares) => setReverseShares(shares));
   };
 
   useEffect(() => {
@@ -49,165 +49,165 @@ const MyShares = () => {
 
   if (!reverseShares) return <CenterLoader />;
   return (
-      <>
-        <Meta title="My shares" />
-        <Group position="apart" align="baseline" mb={20}>
-          <Group align="center" spacing={3} mb={30}>
-            <Title order={3}>My reverse shares</Title>
-            <Tooltip
-                position="bottom"
-                multiline
-                width={220}
-                label="A reverse share allows you to generate a unique URL that allows external users to create a share."
-                events={{ hover: true, focus: false, touch: true }}
-            >
-              <ActionIcon>
-                <TbInfoCircle />
-              </ActionIcon>
-            </Tooltip>
-          </Group>
-          <Button
-              onClick={() =>
-                  showCreateReverseShareModal(
-                      modals,
-                      config.get("smtp.enabled"),
-                      getReverseShares
-                  )
-              }
-              leftIcon={<TbPlus size={20} />}
+    <>
+      <Meta title="My shares" />
+      <Group position="apart" align="baseline" mb={20}>
+        <Group align="center" spacing={3} mb={30}>
+          <Title order={3}>My reverse shares</Title>
+          <Tooltip
+            position="bottom"
+            multiline
+            width={220}
+            label="A reverse share allows you to generate a unique URL that allows external users to create a share."
+            events={{ hover: true, focus: false, touch: true }}
           >
-            Create
-          </Button>
+            <ActionIcon>
+              <TbInfoCircle />
+            </ActionIcon>
+          </Tooltip>
         </Group>
-        {reverseShares.length == 0 ? (
-            <Center style={{ height: "70vh" }}>
-              <Stack align="center" spacing={10}>
-                <Title order={3}>It's empty here 👀</Title>
-                <Text>You don't have any reverse shares.</Text>
-              </Stack>
-            </Center>
-        ) : (
-            <Box sx={{ display: "block", overflowX: "auto" }}>
-              <Table>
-                <thead>
-                <tr>
-                  <th>Shares</th>
-                  <th>Remaining uses</th>
-                  <th>Max share size</th>
-                  <th>Expires at</th>
-                  <th></th>
-                </tr>
-                </thead>
-                <tbody>
-                {reverseShares.map((reverseShare) => (
-                    <tr key={reverseShare.id}>
-                      <td style={{ width: 220 }}>
-                        {reverseShare.shares.length == 0 ? (
-                            <Text color="dimmed" size="sm">
-                              No shares created yet
+        <Button
+          onClick={() =>
+            showCreateReverseShareModal(
+              modals,
+              config.get("smtp.enabled"),
+              getReverseShares
+            )
+          }
+          leftIcon={<TbPlus size={20} />}
+        >
+          Create
+        </Button>
+      </Group>
+      {reverseShares.length == 0 ? (
+        <Center style={{ height: "70vh" }}>
+          <Stack align="center" spacing={10}>
+            <Title order={3}>It's empty here 👀</Title>
+            <Text>You don't have any reverse shares.</Text>
+          </Stack>
+        </Center>
+      ) : (
+        <Box sx={{ display: "block", overflowX: "auto" }}>
+          <Table>
+            <thead>
+              <tr>
+                <th>Shares</th>
+                <th>Remaining uses</th>
+                <th>Max share size</th>
+                <th>Expires at</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {reverseShares.map((reverseShare) => (
+                <tr key={reverseShare.id}>
+                  <td style={{ width: 220 }}>
+                    {reverseShare.shares.length == 0 ? (
+                      <Text color="dimmed" size="sm">
+                        No shares created yet
+                      </Text>
+                    ) : (
+                      <Accordion>
+                        <Accordion.Item
+                          value="customization"
+                          sx={{ borderBottom: "none" }}
+                        >
+                          <Accordion.Control p={0}>
+                            <Text size="sm">
+                              {`${reverseShare.shares.length} share${
+                                reverseShare.shares.length > 1 ? "s" : ""
+                              }`}
                             </Text>
-                        ) : (
-                            <Accordion>
-                              <Accordion.Item
-                                  value="customization"
-                                  sx={{ borderBottom: "none" }}
-                              >
-                                <Accordion.Control p={0}>
-                                  <Text size="sm">
-                                    {`${reverseShare.shares.length} share${
-                                        reverseShare.shares.length > 1 ? "s" : ""
-                                    }`}
+                          </Accordion.Control>
+                          <Accordion.Panel>
+                            {reverseShare.shares.map((share) => (
+                              <Group key={share.id} mb={4}>
+                                <Anchor href={`${appUrl}/share/${share.id}`}>
+                                  <Text maw={120} truncate>
+                                    {share.id}
                                   </Text>
-                                </Accordion.Control>
-                                <Accordion.Panel>
-                                  {reverseShare.shares.map((share) => (
-                                      <Group key={share.id} mb={4}>
-                                        <Anchor href={`${appUrl}/share/${share.id}`}>
-                                          <Text maw={120} truncate>
-                                            {share.id}
-                                          </Text>
-                                        </Anchor>
-                                        <ActionIcon
-                                            color="victoria"
-                                            variant="light"
-                                            size={25}
-                                            onClick={() => {
-                                              if (window.isSecureContext) {
-                                                clipboard.copy(
-                                                    `${appUrl}/share/${share.id}`
-                                                );
-                                                toast.success(
-                                                    "The share link was copied to the keyboard."
-                                                );
-                                              } else {
-                                                showShareLinkModal(
-                                                    modals,
-                                                    share.id,
-                                                    config.get("general.appUrl")
-                                                );
-                                              }
-                                            }}
-                                        >
-                                          <TbLink />
-                                        </ActionIcon>
-                                      </Group>
-                                  ))}
-                                </Accordion.Panel>
-                              </Accordion.Item>
-                            </Accordion>
-                        )}
-                      </td>
-                      <td>{reverseShare.remainingUses}</td>
-                      <td>
-                        {byteToHumanSizeString(parseInt(reverseShare.maxShareSize))}
-                      </td>
-                      <td>
-                        {moment(reverseShare.shareExpiration).unix() === 0
-                            ? "Never"
-                            : moment(reverseShare.shareExpiration).format("LLL")}
-                      </td>
-                      <td>
-                        <Group position="right">
-                          <ActionIcon
-                              color="red"
-                              variant="light"
-                              size={25}
-                              onClick={() => {
-                                modals.openConfirmModal({
-                                  title: `Delete reverse share`,
-                                  children: (
-                                      <Text size="sm">
-                                        Do you really want to delete this reverse share?
-                                        If you do, the associated shares will be deleted
-                                        as well.
-                                      </Text>
-                                  ),
-                                  confirmProps: {
-                                    color: "red",
-                                  },
-                                  labels: { confirm: "Delete", cancel: "Cancel" },
-                                  onConfirm: () => {
-                                    shareService.removeReverseShare(reverseShare.id);
-                                    setReverseShares(
-                                        reverseShares.filter(
-                                            (item) => item.id !== reverseShare.id
-                                        )
-                                    );
-                                  },
-                                });
-                              }}
-                          >
-                            <TbTrash />
-                          </ActionIcon>
-                        </Group>
-                      </td>
-                    </tr>
-                ))}
-                </tbody>
-              </Table>
-            </Box>
-        )}
-      </>
+                                </Anchor>
+                                <ActionIcon
+                                  color="victoria"
+                                  variant="light"
+                                  size={25}
+                                  onClick={() => {
+                                    if (window.isSecureContext) {
+                                      clipboard.copy(
+                                        `${appUrl}/share/${share.id}`
+                                      );
+                                      toast.success(
+                                        "The share link was copied to the keyboard."
+                                      );
+                                    } else {
+                                      showShareLinkModal(
+                                        modals,
+                                        share.id,
+                                        config.get("general.appUrl")
+                                      );
+                                    }
+                                  }}
+                                >
+                                  <TbLink />
+                                </ActionIcon>
+                              </Group>
+                            ))}
+                          </Accordion.Panel>
+                        </Accordion.Item>
+                      </Accordion>
+                    )}
+                  </td>
+                  <td>{reverseShare.remainingUses}</td>
+                  <td>
+                    {byteToHumanSizeString(parseInt(reverseShare.maxShareSize))}
+                  </td>
+                  <td>
+                    {moment(reverseShare.shareExpiration).unix() === 0
+                      ? "Never"
+                      : moment(reverseShare.shareExpiration).format("LLL")}
+                  </td>
+                  <td>
+                    <Group position="right">
+                      <ActionIcon
+                        color="red"
+                        variant="light"
+                        size={25}
+                        onClick={() => {
+                          modals.openConfirmModal({
+                            title: `Delete reverse share`,
+                            children: (
+                              <Text size="sm">
+                                Do you really want to delete this reverse share?
+                                If you do, the associated shares will be deleted
+                                as well.
+                              </Text>
+                            ),
+                            confirmProps: {
+                              color: "red",
+                            },
+                            labels: { confirm: "Delete", cancel: "Cancel" },
+                            onConfirm: () => {
+                              shareService.removeReverseShare(reverseShare.id);
+                              setReverseShares(
+                                reverseShares.filter(
+                                  (item) => item.id !== reverseShare.id
+                                )
+                              );
+                            },
+                          });
+                        }}
+                      >
+                        <TbTrash />
+                      </ActionIcon>
+                    </Group>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </Box>
+      )}
+    </>
   );
 };
 

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -48,8 +48,6 @@ const MyShares = () => {
     getReverseShares();
   }, []);
 
-  console.log(reverseShares);
-
   if (!reverseShares) return <CenterLoader />;
   return (
     <>

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -123,7 +123,10 @@ const MyShares = () => {
                           <Accordion.Panel>
                             {reverseShare.shares.map((share) => (
                               <Group key={share.id} mb={4}>
-                                <Anchor href={`${appUrl}/share/${share.id}`}>
+                                <Anchor
+                                  href={`${appUrl}/share/${share.id}`}
+                                  target="_blank"
+                                >
                                   <Text maw={120} truncate>
                                     {share.id}
                                   </Text>

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -1,6 +1,7 @@
 import {
   Accordion,
   ActionIcon,
+  Anchor,
   Box,
   Button,
   Center,
@@ -34,10 +35,12 @@ const MyShares = () => {
 
   const [reverseShares, setReverseShares] = useState<MyReverseShare[]>();
 
+  const appUrl = config.get("general.appUrl");
+
   const getReverseShares = () => {
     shareService
-      .getMyReverseShares()
-      .then((shares) => setReverseShares(shares));
+        .getMyReverseShares()
+        .then((shares) => setReverseShares(shares));
   };
 
   useEffect(() => {
@@ -46,165 +49,165 @@ const MyShares = () => {
 
   if (!reverseShares) return <CenterLoader />;
   return (
-    <>
-      <Meta title="My shares" />
-      <Group position="apart" align="baseline" mb={20}>
-        <Group align="center" spacing={3} mb={30}>
-          <Title order={3}>My reverse shares</Title>
-          <Tooltip
-            position="bottom"
-            multiline
-            width={220}
-            label="A reverse share allows you to generate a unique URL that allows external users to create a share."
-            events={{ hover: true, focus: false, touch: true }}
+      <>
+        <Meta title="My shares" />
+        <Group position="apart" align="baseline" mb={20}>
+          <Group align="center" spacing={3} mb={30}>
+            <Title order={3}>My reverse shares</Title>
+            <Tooltip
+                position="bottom"
+                multiline
+                width={220}
+                label="A reverse share allows you to generate a unique URL that allows external users to create a share."
+                events={{ hover: true, focus: false, touch: true }}
+            >
+              <ActionIcon>
+                <TbInfoCircle />
+              </ActionIcon>
+            </Tooltip>
+          </Group>
+          <Button
+              onClick={() =>
+                  showCreateReverseShareModal(
+                      modals,
+                      config.get("smtp.enabled"),
+                      getReverseShares
+                  )
+              }
+              leftIcon={<TbPlus size={20} />}
           >
-            <ActionIcon>
-              <TbInfoCircle />
-            </ActionIcon>
-          </Tooltip>
+            Create
+          </Button>
         </Group>
-        <Button
-          onClick={() =>
-            showCreateReverseShareModal(
-              modals,
-              config.get("smtp.enabled"),
-              getReverseShares
-            )
-          }
-          leftIcon={<TbPlus size={20} />}
-        >
-          Create
-        </Button>
-      </Group>
-      {reverseShares.length == 0 ? (
-        <Center style={{ height: "70vh" }}>
-          <Stack align="center" spacing={10}>
-            <Title order={3}>It's empty here 👀</Title>
-            <Text>You don't have any reverse shares.</Text>
-          </Stack>
-        </Center>
-      ) : (
-        <Box sx={{ display: "block", overflowX: "auto" }}>
-          <Table>
-            <thead>
-              <tr>
-                <th>Shares</th>
-                <th>Remaining uses</th>
-                <th>Max share size</th>
-                <th>Expires at</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {reverseShares.map((reverseShare) => (
-                <tr key={reverseShare.id}>
-                  <td style={{ width: 220 }}>
-                    {reverseShare.shares.length == 0 ? (
-                      <Text color="dimmed" size="sm">
-                        No shares created yet
-                      </Text>
-                    ) : (
-                      <Accordion>
-                        <Accordion.Item
-                          value="customization"
-                          sx={{ borderBottom: "none" }}
-                        >
-                          <Accordion.Control p={0}>
-                            <Text size="sm">
-                              {`${reverseShare.shares.length} share${
-                                reverseShare.shares.length > 1 ? "s" : ""
-                              }`}
-                            </Text>
-                          </Accordion.Control>
-                          <Accordion.Panel>
-                            {reverseShare.shares.map((share) => (
-                              <Group key={share.id} mb={4}>
-                                <Text maw={120} truncate>
-                                  {share.id}
-                                </Text>
-                                <ActionIcon
-                                  color="victoria"
-                                  variant="light"
-                                  size={25}
-                                  onClick={() => {
-                                    if (window.isSecureContext) {
-                                      clipboard.copy(
-                                        `${config.get(
-                                          "general.appUrl"
-                                        )}/share/${share.id}`
-                                      );
-                                      toast.success(
-                                        "The share link was copied to the keyboard."
-                                      );
-                                    } else {
-                                      showShareLinkModal(
-                                        modals,
-                                        share.id,
-                                        config.get("general.appUrl")
-                                      );
-                                    }
-                                  }}
-                                >
-                                  <TbLink />
-                                </ActionIcon>
-                              </Group>
-                            ))}
-                          </Accordion.Panel>
-                        </Accordion.Item>
-                      </Accordion>
-                    )}
-                  </td>
-                  <td>{reverseShare.remainingUses}</td>
-                  <td>
-                    {byteToHumanSizeString(parseInt(reverseShare.maxShareSize))}
-                  </td>
-                  <td>
-                    {moment(reverseShare.shareExpiration).unix() === 0
-                      ? "Never"
-                      : moment(reverseShare.shareExpiration).format("LLL")}
-                  </td>
-                  <td>
-                    <Group position="right">
-                      <ActionIcon
-                        color="red"
-                        variant="light"
-                        size={25}
-                        onClick={() => {
-                          modals.openConfirmModal({
-                            title: `Delete reverse share`,
-                            children: (
-                              <Text size="sm">
-                                Do you really want to delete this reverse share?
-                                If you do, the associated shares will be deleted
-                                as well.
-                              </Text>
-                            ),
-                            confirmProps: {
-                              color: "red",
-                            },
-                            labels: { confirm: "Delete", cancel: "Cancel" },
-                            onConfirm: () => {
-                              shareService.removeReverseShare(reverseShare.id);
-                              setReverseShares(
-                                reverseShares.filter(
-                                  (item) => item.id !== reverseShare.id
-                                )
-                              );
-                            },
-                          });
-                        }}
-                      >
-                        <TbTrash />
-                      </ActionIcon>
-                    </Group>
-                  </td>
+        {reverseShares.length == 0 ? (
+            <Center style={{ height: "70vh" }}>
+              <Stack align="center" spacing={10}>
+                <Title order={3}>It's empty here 👀</Title>
+                <Text>You don't have any reverse shares.</Text>
+              </Stack>
+            </Center>
+        ) : (
+            <Box sx={{ display: "block", overflowX: "auto" }}>
+              <Table>
+                <thead>
+                <tr>
+                  <th>Shares</th>
+                  <th>Remaining uses</th>
+                  <th>Max share size</th>
+                  <th>Expires at</th>
+                  <th></th>
                 </tr>
-              ))}
-            </tbody>
-          </Table>
-        </Box>
-      )}
-    </>
+                </thead>
+                <tbody>
+                {reverseShares.map((reverseShare) => (
+                    <tr key={reverseShare.id}>
+                      <td style={{ width: 220 }}>
+                        {reverseShare.shares.length == 0 ? (
+                            <Text color="dimmed" size="sm">
+                              No shares created yet
+                            </Text>
+                        ) : (
+                            <Accordion>
+                              <Accordion.Item
+                                  value="customization"
+                                  sx={{ borderBottom: "none" }}
+                              >
+                                <Accordion.Control p={0}>
+                                  <Text size="sm">
+                                    {`${reverseShare.shares.length} share${
+                                        reverseShare.shares.length > 1 ? "s" : ""
+                                    }`}
+                                  </Text>
+                                </Accordion.Control>
+                                <Accordion.Panel>
+                                  {reverseShare.shares.map((share) => (
+                                      <Group key={share.id} mb={4}>
+                                        <Anchor href={`${appUrl}/share/${share.id}`}>
+                                          <Text maw={120} truncate>
+                                            {share.id}
+                                          </Text>
+                                        </Anchor>
+                                        <ActionIcon
+                                            color="victoria"
+                                            variant="light"
+                                            size={25}
+                                            onClick={() => {
+                                              if (window.isSecureContext) {
+                                                clipboard.copy(
+                                                    `${appUrl}/share/${share.id}`
+                                                );
+                                                toast.success(
+                                                    "The share link was copied to the keyboard."
+                                                );
+                                              } else {
+                                                showShareLinkModal(
+                                                    modals,
+                                                    share.id,
+                                                    config.get("general.appUrl")
+                                                );
+                                              }
+                                            }}
+                                        >
+                                          <TbLink />
+                                        </ActionIcon>
+                                      </Group>
+                                  ))}
+                                </Accordion.Panel>
+                              </Accordion.Item>
+                            </Accordion>
+                        )}
+                      </td>
+                      <td>{reverseShare.remainingUses}</td>
+                      <td>
+                        {byteToHumanSizeString(parseInt(reverseShare.maxShareSize))}
+                      </td>
+                      <td>
+                        {moment(reverseShare.shareExpiration).unix() === 0
+                            ? "Never"
+                            : moment(reverseShare.shareExpiration).format("LLL")}
+                      </td>
+                      <td>
+                        <Group position="right">
+                          <ActionIcon
+                              color="red"
+                              variant="light"
+                              size={25}
+                              onClick={() => {
+                                modals.openConfirmModal({
+                                  title: `Delete reverse share`,
+                                  children: (
+                                      <Text size="sm">
+                                        Do you really want to delete this reverse share?
+                                        If you do, the associated shares will be deleted
+                                        as well.
+                                      </Text>
+                                  ),
+                                  confirmProps: {
+                                    color: "red",
+                                  },
+                                  labels: { confirm: "Delete", cancel: "Cancel" },
+                                  onConfirm: () => {
+                                    shareService.removeReverseShare(reverseShare.id);
+                                    setReverseShares(
+                                        reverseShares.filter(
+                                            (item) => item.id !== reverseShare.id
+                                        )
+                                    );
+                                  },
+                                });
+                              }}
+                          >
+                            <TbTrash />
+                          </ActionIcon>
+                        </Group>
+                      </td>
+                    </tr>
+                ))}
+                </tbody>
+              </Table>
+            </Box>
+        )}
+      </>
   );
 };
 

--- a/frontend/src/pages/account/shares.tsx
+++ b/frontend/src/pages/account/shares.tsx
@@ -16,15 +16,15 @@ import { useModals } from "@mantine/modals";
 import moment from "moment";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { TbLink, TbTrash, TbInfoCircle } from "react-icons/tb";
+import { TbInfoCircle, TbLink, TbTrash } from "react-icons/tb";
+import Meta from "../../components/Meta";
+import showShareInformationsModal from "../../components/account/showShareInformationsModal";
 import showShareLinkModal from "../../components/account/showShareLinkModal";
 import CenterLoader from "../../components/core/CenterLoader";
-import Meta from "../../components/Meta";
 import useConfig from "../../hooks/config.hook";
 import shareService from "../../services/share.service";
 import { MyShare } from "../../types/share.type";
 import toast from "../../utils/toast.util";
-import showShareInformationsModal from "../../components/account/showShareInformationsModal";
 
 const MyShares = () => {
   const modals = useModals();
@@ -122,7 +122,7 @@ const MyShares = () => {
                               }`
                             );
                             toast.success(
-                              "Your link was copied to the keyboard."
+                              "The link was copied to your clipboard."
                             );
                           } else {
                             showShareLinkModal(

--- a/frontend/src/types/share.type.ts
+++ b/frontend/src/types/share.type.ts
@@ -32,6 +32,7 @@ export type MyReverseShare = {
   maxShareSize: string;
   shareExpiration: Date;
   remainingUses: number;
+  token: string;
   shares: MyShare[];
 };
 


### PR DESCRIPTION
I fetched the token from the backend and then I created the upload link, in order to display a link icon to copy the reverse share's link. I also created a modal to display the link when the context isn't secured. I added this because it was yet impossible to copy the link of the reverse share once it was created. Now you can copy it anytime.

Like this branch is child to the other PR, this may cause some other changes but it should normally works.

This is a preview : 

![image](https://github.com/stonith404/pingvin-share/assets/83456236/68a0d9ee-df07-41bc-be91-a9d6c5598ea1)
