### PR TITLE
fix: add translation in toast

### DIFF
--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -425,6 +425,7 @@ export default {
   "common.text.or": "or",
   "common.button.go-back": "Go back",
   "common.notify.copied": "Your link was copied to the clipboard",
+  "common.success": "Success",
 
   "common.error": "Error",
   "common.error.unknown": "An unknown error occurred",

--- a/frontend/src/utils/toast.util.tsx
+++ b/frontend/src/utils/toast.util.tsx
@@ -1,11 +1,13 @@
 import { NotificationProps, showNotification } from "@mantine/notifications";
 import { TbCheck, TbX } from "react-icons/tb";
+import { FormattedMessage } from "react-intl";
+
 const error = (message: string, config?: Omit<NotificationProps, "message">) =>
   showNotification({
     icon: <TbX />,
     color: "red",
     radius: "md",
-    title: "Error",
+    title: <FormattedMessage id="common.error" />,
     message: message,
 
     autoClose: true,
@@ -24,7 +26,7 @@ const success = (
     icon: <TbCheck />,
     color: "green",
     radius: "md",
-    title: "Success",
+    title: <FormattedMessage id="common.success" />,
     message: message,
     autoClose: true,
     ...config,


### PR DESCRIPTION
I added the translation of the success or error messages in the toast notifications because they were still hardcoded.