### PR TITLE
chore(frontend/share): Displays the never expire checkbox if the system allows.

### DIFF
--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -282,10 +282,11 @@ const CreateUploadModalBody = ({
                   />
                 </Col>
               </Grid>
-              <Checkbox
+              { options.maxExpirationInHours == 0 && <Checkbox
                 label={t("upload.modal.expires.never-long")}
                 {...form.getInputProps("never_expires")}
               />
+              }
               <Text
                 italic
                 size="xs"

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -214,7 +214,7 @@ export default {
   "upload.modal.not-signed-in-description": "你将不能删除你的共享或查看访问次数",
   "upload.modal.expires.never": "永不",
   "upload.modal.expires.never-long": "永不过期",
-  "upload.modal.expires.error.too-long": "Expiration exceeds maximum expiration date of {max}.",
+  "upload.modal.expires.error.too-long": "您设置的过期时间超出了系统上限 {max}。",
   "upload.modal.link.label": "共享链接",
   "upload.modal.expires.label": "过期时间",
   "upload.modal.expires.minute-singular": "1 分钟",


### PR DESCRIPTION
I believe that after the administrator has set the maximum share expiration date in the sharing configuration of the system, users cannot check the Never expire option when creating a share.

<img width="500" alt="image" src="https://github.com/stonith404/pingvin-share/assets/30215105/d8c43358-47ee-41a5-b15d-bfe1f972556b">
->
<img width="200" alt="image" src="https://github.com/stonith404/pingvin-share/assets/30215105/1ba6ac2b-b9b2-4be1-83f5-68580961bd00">

So in this case, I've hidden the never expire option. (Maybe disabling is a better option?)

<img width="300" alt="image" src="https://github.com/stonith404/pingvin-share/assets/30215105/167172cd-366c-4063-b1be-3a98f98c5bd2">

