### PR TITLE
feat(frontend): add navigateToLink button for CopyTextField. close #372.

### DIFF
--- a/frontend/src/components/upload/CopyTextField.tsx
+++ b/frontend/src/components/upload/CopyTextField.tsx
@@ -1,11 +1,12 @@
-import { ActionIcon, TextInput } from "@mantine/core";
+import { ActionIcon, TextInput, Tooltip } from "@mantine/core";
 import { useClipboard } from "@mantine/hooks";
 import { useRef, useState } from "react";
 import { TbCheck, TbCopy } from "react-icons/tb";
+import { IoOpenOutline } from "react-icons/io5";
 import useTranslate from "../../hooks/useTranslate.hook";
 import toast from "../../utils/toast.util";
 
-function CopyTextField(props: { link: string }) {
+function CopyTextField(props: { link: string; openBtn?: boolean }) {
   const clipboard = useClipboard({ timeout: 500 });
   const t = useTranslate();
 
@@ -37,12 +38,29 @@ function CopyTextField(props: { link: string }) {
           setTextClicked(true);
         }
       }}
+      rightSectionWidth={62}
       rightSection={
-        window.isSecureContext && (
-          <ActionIcon onClick={copyLink}>
-            {checkState ? <TbCheck /> : <TbCopy />}
-          </ActionIcon>
-        )
+        <>
+          {props.openBtn !== false && (
+            <Tooltip
+              label={t("common.text.navigate-to-link")}
+              position="top"
+              offset={-2}
+              openDelay={200}
+            >
+              <a href={props.link}>
+                <ActionIcon>
+                  <IoOpenOutline />
+                </ActionIcon>
+              </a>
+            </Tooltip>
+          )}
+          {window.isSecureContext && (
+            <ActionIcon onClick={copyLink}>
+              {checkState ? <TbCheck /> : <TbCopy />}
+            </ActionIcon>
+          )}
+        </>
       }
     />
   );

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -282,11 +282,12 @@ const CreateUploadModalBody = ({
                   />
                 </Col>
               </Grid>
-              { options.maxExpirationInHours == 0 && <Checkbox
-                label={t("upload.modal.expires.never-long")}
-                {...form.getInputProps("never_expires")}
-              />
-              }
+              {options.maxExpirationInHours == 0 && (
+                <Checkbox
+                  label={t("upload.modal.expires.never-long")}
+                  {...form.getInputProps("never_expires")}
+                />
+              )}
               <Text
                 italic
                 size="xs"

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -526,6 +526,7 @@ export default {
   "common.button.generate": "Generate",
   "common.button.done": "Done",
   "common.text.link": "Link",
+  "common.text.navigate-to-link": "Go to the link",
   "common.text.or": "or",
   "common.button.go-back": "Go back",
   "common.notify.copied": "Your link was copied to the clipboard",

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -404,6 +404,7 @@ export default {
   "common.button.generate": "生成",
   "common.button.done": "完成",
   "common.text.link": "链接",
+  "common.text.navigate-to-link": "访问链接",
   "common.text.or": "或",
   "common.button.go-back": "返回",
   "common.notify.copied": "已复制到剪贴板",


### PR DESCRIPTION
At present, I see 3 places to use this link field component. I feel quite suitable for adding this function. The Navigate to Link button is optional and enabled by default.

<img width="1000" alt="image" src="https://github.com/stonith404/pingvin-share/assets/30215105/8cdcbadd-f9dc-48f1-9979-c904a6d9e6d1">

<img width="1003" alt="image" src="https://github.com/stonith404/pingvin-share/assets/30215105/25e7d819-da3e-450d-bc35-d028043636fd">
