### PR TITLE
feat: add name property to share

### DIFF
--- a/backend/prisma/migrations/20240501154254_share_name_property/migration.sql
+++ b/backend/prisma/migrations/20240501154254_share_name_property/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Share" ADD COLUMN "name" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -75,6 +75,7 @@ model Share {
   id        String   @id @default(uuid())
   createdAt DateTime @default(now())
 
+  name          String?
   uploadLocked  Boolean  @default(false)
   isZipReady    Boolean  @default(false)
   views         Int      @default(0)

--- a/backend/src/reverseShare/dto/reverseShareTokenWithShares.ts
+++ b/backend/src/reverseShare/dto/reverseShareTokenWithShares.ts
@@ -13,7 +13,7 @@ export class ReverseShareTokenWithShares extends OmitType(ReverseShareDTO, [
   @Type(() => OmitType(MyShareDTO, ["recipients", "hasPassword"] as const))
   shares: Omit<
     MyShareDTO,
-    "recipients" | "files" | "from" | "fromList" | "hasPassword"
+    "recipients" | "files" | "from" | "fromList" | "hasPassword" | "size"
   >[];
 
   @Expose()

--- a/backend/src/share/dto/createShare.dto.ts
+++ b/backend/src/share/dto/createShare.dto.ts
@@ -18,6 +18,10 @@ export class CreateShareDTO {
   @Length(3, 50)
   id: string;
 
+  @Length(3, 30)
+  @IsOptional()
+  name: string;
+
   @IsString()
   expiration: string;
 

--- a/backend/src/share/dto/share.dto.ts
+++ b/backend/src/share/dto/share.dto.ts
@@ -7,6 +7,9 @@ export class ShareDTO {
   id: string;
 
   @Expose()
+  name?: string;
+
+  @Expose()
   expiration: Date;
 
   @Expose()
@@ -22,6 +25,9 @@ export class ShareDTO {
 
   @Expose()
   hasPassword: boolean;
+
+  @Expose()
+  size: number;
 
   from(partial: Partial<ShareDTO>) {
     return plainToClass(ShareDTO, partial, { excludeExtraneousValues: true });

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -29,7 +29,7 @@ export class ShareService {
     private config: ConfigService,
     private jwtService: JwtService,
     private reverseShareService: ReverseShareService,
-    private clamScanService: ClamScanService
+    private clamScanService: ClamScanService,
   ) {}
 
   async create(share: CreateShareDTO, user?: User, reverseShareToken?: string) {
@@ -47,7 +47,7 @@ export class ShareService {
 
     // If share is created by a reverse share token override the expiration date
     const reverseShare = await this.reverseShareService.getByToken(
-      reverseShareToken
+      reverseShareToken,
     );
     if (reverseShare) {
       expirationDate = reverseShare.shareExpiration;
@@ -65,7 +65,7 @@ export class ShareService {
               .toDate())
       ) {
         throw new BadRequestException(
-          "Expiration date exceeds maximum expiration date"
+          "Expiration date exceeds maximum expiration date",
         );
       }
 
@@ -140,13 +140,13 @@ export class ShareService {
 
     if (share.files.length == 0)
       throw new BadRequestException(
-        "You need at least on file in your share to complete it."
+        "You need at least on file in your share to complete it.",
       );
 
     // Asynchronously create a zip of all files
     if (share.files.length > 1)
       this.createZip(id).then(() =>
-        this.prisma.share.update({ where: { id }, data: { isZipReady: true } })
+        this.prisma.share.update({ where: { id }, data: { isZipReady: true } }),
       );
 
     // Send email for each recipient
@@ -156,7 +156,7 @@ export class ShareService {
         share.id,
         share.creator,
         share.description,
-        share.expiration
+        share.expiration,
       );
     }
 
@@ -167,7 +167,7 @@ export class ShareService {
     ) {
       await this.emailService.sendMailToReverseShareCreator(
         share.reverseShare.creator.email,
-        share.id
+        share.id,
       );
     }
 
@@ -299,7 +299,7 @@ export class ShareService {
     if (share.security?.maxViews && share.security.maxViews <= share.views) {
       throw new ForbiddenException(
         "Maximum views exceeded",
-        "share_max_views_exceeded"
+        "share_max_views_exceeded",
       );
     }
 
@@ -319,7 +319,7 @@ export class ShareService {
       {
         expiresIn: moment(expiration).diff(new Date(), "seconds") + "s",
         secret: this.config.get("internal.jwtSecret"),
-      }
+      },
     );
   }
 

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -29,7 +29,7 @@ export class ShareService {
     private config: ConfigService,
     private jwtService: JwtService,
     private reverseShareService: ReverseShareService,
-    private clamScanService: ClamScanService,
+    private clamScanService: ClamScanService
   ) {}
 
   async create(share: CreateShareDTO, user?: User, reverseShareToken?: string) {
@@ -47,7 +47,7 @@ export class ShareService {
 
     // If share is created by a reverse share token override the expiration date
     const reverseShare = await this.reverseShareService.getByToken(
-      reverseShareToken,
+      reverseShareToken
     );
     if (reverseShare) {
       expirationDate = reverseShare.shareExpiration;
@@ -65,7 +65,7 @@ export class ShareService {
               .toDate())
       ) {
         throw new BadRequestException(
-          "Expiration date exceeds maximum expiration date",
+          "Expiration date exceeds maximum expiration date"
         );
       }
 
@@ -140,13 +140,13 @@ export class ShareService {
 
     if (share.files.length == 0)
       throw new BadRequestException(
-        "You need at least on file in your share to complete it.",
+        "You need at least on file in your share to complete it."
       );
 
     // Asynchronously create a zip of all files
     if (share.files.length > 1)
       this.createZip(id).then(() =>
-        this.prisma.share.update({ where: { id }, data: { isZipReady: true } }),
+        this.prisma.share.update({ where: { id }, data: { isZipReady: true } })
       );
 
     // Send email for each recipient
@@ -156,7 +156,7 @@ export class ShareService {
         share.id,
         share.creator,
         share.description,
-        share.expiration,
+        share.expiration
       );
     }
 
@@ -167,7 +167,7 @@ export class ShareService {
     ) {
       await this.emailService.sendMailToReverseShareCreator(
         share.reverseShare.creator.email,
-        share.id,
+        share.id
       );
     }
 
@@ -214,6 +214,7 @@ export class ShareService {
     return shares.map((share) => {
       return {
         ...share,
+        size: share.files.reduce((acc, file) => acc + parseInt(file.size), 0),
         recipients: share.recipients.map((recipients) => recipients.email),
       };
     });
@@ -298,7 +299,7 @@ export class ShareService {
     if (share.security?.maxViews && share.security.maxViews <= share.views) {
       throw new ForbiddenException(
         "Maximum views exceeded",
-        "share_max_views_exceeded",
+        "share_max_views_exceeded"
       );
     }
 
@@ -318,7 +319,7 @@ export class ShareService {
       {
         expiresIn: moment(expiration).diff(new Date(), "seconds") + "s",
         secret: this.config.get("internal.jwtSecret"),
-      },
+      }
     );
   }
 

--- a/backend/test/newman-system-tests.json
+++ b/backend/test/newman-system-tests.json
@@ -432,7 +432,7 @@
 											"    const responseBody = pm.response.json();",
 											"    pm.expect(responseBody).to.have.property(\"id\")",
 											"    pm.expect(responseBody).to.have.property(\"expiration\")",
-											"    pm.expect(Object.keys(responseBody).length).be.equal(3)",
+											"    pm.expect(Object.keys(responseBody).length).be.equal(4)",
 											"});",
 											""
 										],

--- a/backend/test/newman-system-tests.json
+++ b/backend/test/newman-system-tests.json
@@ -626,7 +626,7 @@
 											"    const responseBody = pm.response.json();",
 											"    pm.expect(responseBody).to.have.property(\"id\")",
 											"    pm.expect(responseBody).to.have.property(\"expiration\")",
-											"    pm.expect(Object.keys(responseBody).length).be.equal(3)",
+											"    pm.expect(Object.keys(responseBody).length).be.equal(4)",
 											"});",
 											""
 										],

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -12,18 +12,15 @@ const showShareInformationsModal = (
   modals: ModalsContextProps,
   share: MyShare,
   appUrl: string,
-  maxShareSize: number,
+  maxShareSize: number
 ) => {
   const t = translateOutsideContext();
   const link = `${appUrl}/s/${share.id}`;
 
-  let shareSize: number = 0;
-  for (let file of share.files as FileMetaData[])
-    shareSize += parseInt(file.size);
 
-  const formattedShareSize = byteToHumanSizeString(shareSize);
+  const formattedShareSize = byteToHumanSizeString(share.size);
   const formattedMaxShareSize = byteToHumanSizeString(maxShareSize);
-  const shareSizeProgress = (shareSize / maxShareSize) * 100;
+  const shareSizeProgress = (share.size / maxShareSize) * 100;
 
   const formattedCreatedAt = moment(share.createdAt).format("LLL");
   const formattedExpiration =
@@ -42,12 +39,18 @@ const showShareInformationsModal = (
           </b>
           {share.id}
         </Text>
+        <Text size="sm">
+          <b>
+            <FormattedMessage id="account.shares.table.name" />:{" "}
+          </b>
+          {share.name || "-"}
+        </Text>
 
         <Text size="sm">
           <b>
             <FormattedMessage id="account.shares.table.description" />:{" "}
           </b>
-          {share.description || "No description"}
+          {share.description || "-"}
         </Text>
 
         <Text size="sm">
@@ -75,15 +78,15 @@ const showShareInformationsModal = (
         </Text>
 
         <Flex align="center" justify="center">
-          {shareSize / maxShareSize < 0.1 && (
+          {share.size / maxShareSize < 0.1 && (
             <Text size="xs" style={{ marginRight: "4px" }}>
               {formattedShareSize}
             </Text>
           )}
           <Progress
             value={shareSizeProgress}
-            label={shareSize / maxShareSize >= 0.1 ? formattedShareSize : ""}
-            style={{ width: shareSize / maxShareSize < 0.1 ? "70%" : "80%" }}
+            label={share.size / maxShareSize >= 0.1 ? formattedShareSize : ""}
+            style={{ width: share.size / maxShareSize < 0.1 ? "70%" : "80%" }}
             size="xl"
             radius="xl"
           />

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -12,11 +12,10 @@ const showShareInformationsModal = (
   modals: ModalsContextProps,
   share: MyShare,
   appUrl: string,
-  maxShareSize: number
+  maxShareSize: number,
 ) => {
   const t = translateOutsideContext();
   const link = `${appUrl}/s/${share.id}`;
-
 
   const formattedShareSize = byteToHumanSizeString(share.size);
   const formattedMaxShareSize = byteToHumanSizeString(maxShareSize);

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -42,7 +42,7 @@ const showCreateUploadModal = (
     maxExpirationInHours: number;
   },
   files: FileUpload[],
-  uploadCallback: (createShare: CreateShare, files: FileUpload[]) => void,
+  uploadCallback: (createShare: CreateShare, files: FileUpload[]) => void
 ) => {
   const t = translateOutsideContext();
 
@@ -92,11 +92,16 @@ const CreateUploadModalBody = ({
       .matches(new RegExp("^[a-zA-Z0-9_-]*$"), {
         message: t("upload.modal.link.error.invalid"),
       }),
+    name: yup
+      .string()
+      .transform((value) => value || undefined)
+      .min(3, t("common.error.too-short", { length: 3 }))
+      .max(30, t("common.error.too-long", { length: 30 })),
     password: yup
       .string()
       .transform((value) => value || undefined)
-      .min(3)
-      .max(30),
+      .min(3, t("common.error.too-short", { length: 3 }))
+      .max(30, t("common.error.too-long", { length: 30 })),
     maxViews: yup
       .number()
       .transform((value) => value || undefined)
@@ -105,6 +110,7 @@ const CreateUploadModalBody = ({
 
   const form = useForm({
     initialValues: {
+      name: undefined,
       link: generatedLink,
       recipients: [] as string[],
       password: undefined,
@@ -129,15 +135,15 @@ const CreateUploadModalBody = ({
         form.values.expiration_num,
         form.values.expiration_unit.replace(
           "-",
-          "",
-        ) as moment.unitOfTime.DurationConstructor,
+          ""
+        ) as moment.unitOfTime.DurationConstructor
       );
 
       if (
         options.maxExpirationInHours != 0 &&
         (form.values.never_expires ||
           expirationDate.isAfter(
-            moment().add(options.maxExpirationInHours, "hours"),
+            moment().add(options.maxExpirationInHours, "hours")
           ))
       ) {
         form.setFieldError(
@@ -146,7 +152,7 @@ const CreateUploadModalBody = ({
             max: moment
               .duration(options.maxExpirationInHours, "hours")
               .humanize(),
-          }),
+          })
         );
         return;
       }
@@ -154,6 +160,7 @@ const CreateUploadModalBody = ({
       uploadCallback(
         {
           id: values.link,
+          name: values.name,
           expiration: expirationString,
           recipients: values.recipients,
           description: values.description,
@@ -162,7 +169,7 @@ const CreateUploadModalBody = ({
             maxViews: values.maxViews || undefined,
           },
         },
-        files,
+        files
       );
       modals.closeAll();
     }
@@ -199,7 +206,7 @@ const CreateUploadModalBody = ({
                   "link",
                   Buffer.from(Math.random().toString(), "utf8")
                     .toString("base64")
-                    .substr(10, 7),
+                    .substr(10, 7)
                 )
               }
             >
@@ -300,7 +307,7 @@ const CreateUploadModalBody = ({
                     neverExpires: t("upload.modal.completed.never-expires"),
                     expiresOn: t("upload.modal.completed.expires-on"),
                   },
-                  form,
+                  form
                 )}
               </Text>
             </>
@@ -308,14 +315,21 @@ const CreateUploadModalBody = ({
           <Accordion>
             <Accordion.Item value="description" sx={{ borderBottom: "none" }}>
               <Accordion.Control>
-                <FormattedMessage id="upload.modal.accordion.description.title" />
+                <FormattedMessage id="upload.modal.accordion.name-and-description.title" />
               </Accordion.Control>
               <Accordion.Panel>
                 <Stack align="stretch">
+                  <TextInput
+                    variant="filled"
+                    placeholder={t(
+                      "upload.modal.accordion.name-and-description.name.placeholder"
+                    )}
+                    {...form.getInputProps("name")}
+                  />
                   <Textarea
                     variant="filled"
                     placeholder={t(
-                      "upload.modal.accordion.description.placeholder",
+                      "upload.modal.accordion.name-and-description.description.placeholder"
                     )}
                     {...form.getInputProps("description")}
                   />
@@ -339,7 +353,7 @@ const CreateUploadModalBody = ({
                       if (!query.match(/^\S+@\S+\.\S+$/)) {
                         form.setFieldError(
                           "recipients",
-                          t("upload.modal.accordion.email.invalid-email"),
+                          t("upload.modal.accordion.email.invalid-email")
                         );
                       } else {
                         form.setFieldError("recipients", null);
@@ -365,7 +379,7 @@ const CreateUploadModalBody = ({
                   <PasswordInput
                     variant="filled"
                     placeholder={t(
-                      "upload.modal.accordion.security.password.placeholder",
+                      "upload.modal.accordion.security.password.placeholder"
                     )}
                     label={t("upload.modal.accordion.security.password.label")}
                     autoComplete="off"
@@ -376,7 +390,7 @@ const CreateUploadModalBody = ({
                     type="number"
                     variant="filled"
                     placeholder={t(
-                      "upload.modal.accordion.security.max-views.placeholder",
+                      "upload.modal.accordion.security.max-views.placeholder"
                     )}
                     label={t("upload.modal.accordion.security.max-views.label")}
                     {...form.getInputProps("maxViews")}

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -42,7 +42,7 @@ const showCreateUploadModal = (
     maxExpirationInHours: number;
   },
   files: FileUpload[],
-  uploadCallback: (createShare: CreateShare, files: FileUpload[]) => void
+  uploadCallback: (createShare: CreateShare, files: FileUpload[]) => void,
 ) => {
   const t = translateOutsideContext();
 
@@ -135,15 +135,15 @@ const CreateUploadModalBody = ({
         form.values.expiration_num,
         form.values.expiration_unit.replace(
           "-",
-          ""
-        ) as moment.unitOfTime.DurationConstructor
+          "",
+        ) as moment.unitOfTime.DurationConstructor,
       );
 
       if (
         options.maxExpirationInHours != 0 &&
         (form.values.never_expires ||
           expirationDate.isAfter(
-            moment().add(options.maxExpirationInHours, "hours")
+            moment().add(options.maxExpirationInHours, "hours"),
           ))
       ) {
         form.setFieldError(
@@ -152,7 +152,7 @@ const CreateUploadModalBody = ({
             max: moment
               .duration(options.maxExpirationInHours, "hours")
               .humanize(),
-          })
+          }),
         );
         return;
       }
@@ -169,7 +169,7 @@ const CreateUploadModalBody = ({
             maxViews: values.maxViews || undefined,
           },
         },
-        files
+        files,
       );
       modals.closeAll();
     }
@@ -206,7 +206,7 @@ const CreateUploadModalBody = ({
                   "link",
                   Buffer.from(Math.random().toString(), "utf8")
                     .toString("base64")
-                    .substr(10, 7)
+                    .substr(10, 7),
                 )
               }
             >
@@ -307,7 +307,7 @@ const CreateUploadModalBody = ({
                     neverExpires: t("upload.modal.completed.never-expires"),
                     expiresOn: t("upload.modal.completed.expires-on"),
                   },
-                  form
+                  form,
                 )}
               </Text>
             </>
@@ -322,14 +322,14 @@ const CreateUploadModalBody = ({
                   <TextInput
                     variant="filled"
                     placeholder={t(
-                      "upload.modal.accordion.name-and-description.name.placeholder"
+                      "upload.modal.accordion.name-and-description.name.placeholder",
                     )}
                     {...form.getInputProps("name")}
                   />
                   <Textarea
                     variant="filled"
                     placeholder={t(
-                      "upload.modal.accordion.name-and-description.description.placeholder"
+                      "upload.modal.accordion.name-and-description.description.placeholder",
                     )}
                     {...form.getInputProps("description")}
                   />
@@ -353,7 +353,7 @@ const CreateUploadModalBody = ({
                       if (!query.match(/^\S+@\S+\.\S+$/)) {
                         form.setFieldError(
                           "recipients",
-                          t("upload.modal.accordion.email.invalid-email")
+                          t("upload.modal.accordion.email.invalid-email"),
                         );
                       } else {
                         form.setFieldError("recipients", null);
@@ -379,7 +379,7 @@ const CreateUploadModalBody = ({
                   <PasswordInput
                     variant="filled"
                     placeholder={t(
-                      "upload.modal.accordion.security.password.placeholder"
+                      "upload.modal.accordion.security.password.placeholder",
                     )}
                     label={t("upload.modal.accordion.security.password.label")}
                     autoComplete="off"
@@ -390,7 +390,7 @@ const CreateUploadModalBody = ({
                     type="number"
                     variant="filled"
                     placeholder={t(
-                      "upload.modal.accordion.security.max-views.placeholder"
+                      "upload.modal.accordion.security.max-views.placeholder",
                     )}
                     label={t("upload.modal.accordion.security.max-views.label")}
                     {...form.getInputProps("maxViews")}

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -307,8 +307,9 @@ export default {
   "upload.modal.expires.year-singular": "Year",
   "upload.modal.expires.year-plural": "Years",
 
-  "upload.modal.accordion.description.title": "Description",
-  "upload.modal.accordion.description.placeholder":
+  "upload.modal.accordion.name-and-description.title": "Name and description",
+  "upload.modal.accordion.name-and-description.name.placeholder": "Name",
+  "upload.modal.accordion.name-and-description.description.placeholder":
     "Note for the recipients of this share",
 
   "upload.modal.accordion.email.title": "Email recipients",

--- a/frontend/src/pages/account/shares.tsx
+++ b/frontend/src/pages/account/shares.tsx
@@ -68,7 +68,7 @@ const MyShares = () => {
           <Table>
             <thead>
               <tr>
-              <th>
+                <th>
                   <FormattedMessage id="account.shares.table.id" />
                 </th>
                 <th>

--- a/frontend/src/pages/account/shares.tsx
+++ b/frontend/src/pages/account/shares.tsx
@@ -68,15 +68,12 @@ const MyShares = () => {
           <Table>
             <thead>
               <tr>
+              <th>
+                  <FormattedMessage id="account.shares.table.id" />
+                </th>
                 <th>
                   <FormattedMessage id="account.shares.table.name" />
                 </th>
-                <MediaQuery smallerThan="md" styles={{ display: "none" }}>
-                  <th>
-                    <FormattedMessage id="account.shares.table.description" />
-                  </th>
-                </MediaQuery>
-
                 <th>
                   <FormattedMessage id="account.shares.table.visitors" />
                 </th>
@@ -90,18 +87,7 @@ const MyShares = () => {
               {shares.map((share) => (
                 <tr key={share.id}>
                   <td>{share.id}</td>
-                  <MediaQuery smallerThan="sm" styles={{ display: "none" }}>
-                    <td
-                      style={{
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                        maxWidth: "300px",
-                      }}
-                    >
-                      {share.description || ""}
-                    </td>
-                  </MediaQuery>
+                  <td>{share.name}</td>
                   <td>{share.views}</td>
                   <td>
                     {moment(share.expiration).unix() === 0

--- a/frontend/src/pages/share/[shareId]/index.tsx
+++ b/frontend/src/pages/share/[shareId]/index.tsx
@@ -91,7 +91,7 @@ const Share = ({ shareId }: { shareId: string }) => {
   return (
     <>
       <Meta
-        title={t("share.title", { shareId: share?.name || shareId})}
+        title={t("share.title", { shareId: share?.name || shareId })}
         description={t("share.description")}
       />
 

--- a/frontend/src/pages/share/[shareId]/index.tsx
+++ b/frontend/src/pages/share/[shareId]/index.tsx
@@ -91,13 +91,13 @@ const Share = ({ shareId }: { shareId: string }) => {
   return (
     <>
       <Meta
-        title={t("share.title", { shareId })}
+        title={t("share.title", { shareId: share?.name || shareId})}
         description={t("share.description")}
       />
 
       <Group position="apart" mb="lg">
         <Box style={{ maxWidth: "70%" }}>
-          <Title order={3}>{share?.id}</Title>
+          <Title order={3}>{share?.name || share?.id}</Title>
           <Text size="sm">{share?.description}</Text>
         </Box>
         {share?.files.length > 1 && <DownloadAllButton shareId={shareId} />}

--- a/frontend/src/types/share.type.ts
+++ b/frontend/src/types/share.type.ts
@@ -2,15 +2,18 @@ import User from "./user.type";
 
 export type Share = {
   id: string;
+  name?: string;
   files: any;
   creator: User;
   description?: string;
   expiration: Date;
+  size: number;
   hasPassword: boolean;
 };
 
 export type CreateShare = {
   id: string;
+  name?: string;
   description?: string;
   recipients: string[];
   expiration: string;


### PR DESCRIPTION
This pull request adds the ability to define the name of a share.

It can be added while starting the upload:
![Screenshot 2024-05-03 at 18 02 02@2x](https://github.com/stonith404/pingvin-share/assets/58886915/7445fdde-d7aa-46dd-9244-1a45f6aad0f3)


And it will be displayed on the share page
![Screenshot 2024-05-03 at 18 02 21@2x](https://github.com/stonith404/pingvin-share/assets/58886915/9d4512b7-d323-437e-b924-96e0a9191513)

...and on on the "My Shares" page:
![Screenshot 2024-05-03 at 18 03 56@2x](https://github.com/stonith404/pingvin-share/assets/58886915/a6409edb-8cd9-4777-9811-66e62c9680f6)



Closes #430