### PR TITLE
feat: add more options to reverse shares

### DIFF
--- a/backend/prisma/migrations/20240609145325_add_simplied_field_for_reverse_share/migration.sql
+++ b/backend/prisma/migrations/20240609145325_add_simplied_field_for_reverse_share/migration.sql
@@ -1,0 +1,20 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_ReverseShare" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "token" TEXT NOT NULL,
+    "shareExpiration" DATETIME NOT NULL,
+    "maxShareSize" TEXT NOT NULL,
+    "sendEmailNotification" BOOLEAN NOT NULL,
+    "remainingUses" INTEGER NOT NULL,
+    "simplified" BOOLEAN NOT NULL DEFAULT false,
+    "creatorId" TEXT NOT NULL,
+    CONSTRAINT "ReverseShare_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_ReverseShare" ("createdAt", "creatorId", "id", "maxShareSize", "remainingUses", "sendEmailNotification", "shareExpiration", "token") SELECT "createdAt", "creatorId", "id", "maxShareSize", "remainingUses", "sendEmailNotification", "shareExpiration", "token" FROM "ReverseShare";
+DROP TABLE "ReverseShare";
+ALTER TABLE "new_ReverseShare" RENAME TO "ReverseShare";
+CREATE UNIQUE INDEX "ReverseShare_token_key" ON "ReverseShare"("token");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/backend/prisma/migrations/20240725141038_add_public_access_field_for_reverse_share/migration.sql
+++ b/backend/prisma/migrations/20240725141038_add_public_access_field_for_reverse_share/migration.sql
@@ -1,0 +1,22 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_ReverseShare" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "token" TEXT NOT NULL,
+    "shareExpiration" DATETIME NOT NULL,
+    "maxShareSize" TEXT NOT NULL,
+    "sendEmailNotification" BOOLEAN NOT NULL,
+    "remainingUses" INTEGER NOT NULL,
+    "simplified" BOOLEAN NOT NULL DEFAULT false,
+    "publicAccess" BOOLEAN NOT NULL DEFAULT true,
+    "creatorId" TEXT NOT NULL,
+    CONSTRAINT "ReverseShare_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_ReverseShare" ("createdAt", "creatorId", "id", "maxShareSize", "remainingUses", "sendEmailNotification", "shareExpiration", "simplified", "token") SELECT "createdAt", "creatorId", "id", "maxShareSize", "remainingUses", "sendEmailNotification", "shareExpiration", "simplified", "token" FROM "ReverseShare";
+DROP TABLE "ReverseShare";
+ALTER TABLE "new_ReverseShare" RENAME TO "ReverseShare";
+CREATE UNIQUE INDEX "ReverseShare_token_key" ON "ReverseShare"("token");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -103,7 +103,8 @@ model ReverseShare {
   maxShareSize          String
   sendEmailNotification Boolean
   remainingUses         Int
-  simplified   Boolean @default(false)
+  simplified            Boolean  @default(false)
+  publicAccess          Boolean  @default(true)
 
   creatorId String
   creator   User   @relation(fields: [creatorId], references: [id], onDelete: Cascade)

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -103,6 +103,7 @@ model ReverseShare {
   maxShareSize          String
   sendEmailNotification Boolean
   remainingUses         Int
+  simplified   Boolean @default(false)
 
   creatorId String
   creator   User   @relation(fields: [creatorId], references: [id], onDelete: Cascade)

--- a/backend/src/file/guard/fileSecurity.guard.ts
+++ b/backend/src/file/guard/fileSecurity.guard.ts
@@ -9,14 +9,16 @@ import * as moment from "moment";
 import { PrismaService } from "src/prisma/prisma.service";
 import { ShareSecurityGuard } from "src/share/guard/shareSecurity.guard";
 import { ShareService } from "src/share/share.service";
+import { ConfigService } from 'src/config/config.service';
 
 @Injectable()
 export class FileSecurityGuard extends ShareSecurityGuard {
   constructor(
     private _shareService: ShareService,
     private _prisma: PrismaService,
+    _config: ConfigService,
   ) {
-    super(_shareService, _prisma);
+    super(_shareService, _prisma, _config);
   }
 
   async canActivate(context: ExecutionContext) {

--- a/backend/src/file/guard/fileSecurity.guard.ts
+++ b/backend/src/file/guard/fileSecurity.guard.ts
@@ -9,7 +9,7 @@ import * as moment from "moment";
 import { PrismaService } from "src/prisma/prisma.service";
 import { ShareSecurityGuard } from "src/share/guard/shareSecurity.guard";
 import { ShareService } from "src/share/share.service";
-import { ConfigService } from 'src/config/config.service';
+import { ConfigService } from "src/config/config.service";
 
 @Injectable()
 export class FileSecurityGuard extends ShareSecurityGuard {

--- a/backend/src/reverseShare/dto/createReverseShare.dto.ts
+++ b/backend/src/reverseShare/dto/createReverseShare.dto.ts
@@ -16,4 +16,7 @@ export class CreateReverseShareDTO {
 
   @IsBoolean()
   simplified: boolean;
+
+  @IsBoolean()
+  publicAccess: boolean;
 }

--- a/backend/src/reverseShare/dto/createReverseShare.dto.ts
+++ b/backend/src/reverseShare/dto/createReverseShare.dto.ts
@@ -13,4 +13,7 @@ export class CreateReverseShareDTO {
   @Min(1)
   @Max(1000)
   maxUseCount: number;
+
+  @IsBoolean()
+  simplified: boolean;
 }

--- a/backend/src/reverseShare/dto/reverseShare.dto.ts
+++ b/backend/src/reverseShare/dto/reverseShare.dto.ts
@@ -13,6 +13,9 @@ export class ReverseShareDTO {
   @Expose()
   token: string;
 
+  @Expose()
+  simplified: boolean;
+
   from(partial: Partial<ReverseShareDTO>) {
     return plainToClass(ReverseShareDTO, partial, {
       excludeExtraneousValues: true,

--- a/backend/src/reverseShare/reverseShare.service.ts
+++ b/backend/src/reverseShare/reverseShare.service.ts
@@ -50,6 +50,7 @@ export class ReverseShareService {
         maxShareSize: data.maxShareSize,
         sendEmailNotification: data.sendEmailNotification,
         simplified: data.simplified,
+        publicAccess: data.publicAccess,
         creatorId,
       },
     });

--- a/backend/src/reverseShare/reverseShare.service.ts
+++ b/backend/src/reverseShare/reverseShare.service.ts
@@ -49,6 +49,7 @@ export class ReverseShareService {
         remainingUses: data.maxUseCount,
         maxShareSize: data.maxShareSize,
         sendEmailNotification: data.sendEmailNotification,
+        simplified: data.simplified,
         creatorId,
       },
     });

--- a/backend/src/share/dto/shareComplete.dto.ts
+++ b/backend/src/share/dto/shareComplete.dto.ts
@@ -1,19 +1,19 @@
 import { Expose, plainToClass } from "class-transformer";
 import { ShareDTO } from "./share.dto";
 
-export class ShareCompleteDTO extends ShareDTO {
+export class CompletedShareDTO extends ShareDTO {
   @Expose()
-  isSendEmailToReverseShareCreator?: boolean;
+  notifyReverseShareCreator?: boolean;
 
-  from(partial: Partial<ShareCompleteDTO>) {
-    return plainToClass(ShareCompleteDTO, partial, {
+  from(partial: Partial<CompletedShareDTO>) {
+    return plainToClass(CompletedShareDTO, partial, {
       excludeExtraneousValues: true,
     });
   }
 
-  fromList(partial: Partial<ShareCompleteDTO>[]) {
+  fromList(partial: Partial<CompletedShareDTO>[]) {
     return partial.map((part) =>
-      plainToClass(ShareCompleteDTO, part, { excludeExtraneousValues: true }),
+      plainToClass(CompletedShareDTO, part, { excludeExtraneousValues: true }),
     );
   }
 }

--- a/backend/src/share/dto/shareComplete.dto.ts
+++ b/backend/src/share/dto/shareComplete.dto.ts
@@ -1,0 +1,18 @@
+import { Expose, plainToClass } from "class-transformer";
+import { ShareDTO } from './share.dto';
+
+export class ShareCompleteDTO extends ShareDTO {
+
+  @Expose()
+  isSendEmailToReverseShareCreator?: boolean;
+
+  from(partial: Partial<ShareCompleteDTO>) {
+    return plainToClass(ShareCompleteDTO, partial, { excludeExtraneousValues: true });
+  }
+
+  fromList(partial: Partial<ShareCompleteDTO>[]) {
+    return partial.map((part) =>
+      plainToClass(ShareCompleteDTO, part, { excludeExtraneousValues: true }),
+    );
+  }
+}

--- a/backend/src/share/dto/shareComplete.dto.ts
+++ b/backend/src/share/dto/shareComplete.dto.ts
@@ -1,13 +1,14 @@
 import { Expose, plainToClass } from "class-transformer";
-import { ShareDTO } from './share.dto';
+import { ShareDTO } from "./share.dto";
 
 export class ShareCompleteDTO extends ShareDTO {
-
   @Expose()
   isSendEmailToReverseShareCreator?: boolean;
 
   from(partial: Partial<ShareCompleteDTO>) {
-    return plainToClass(ShareCompleteDTO, partial, { excludeExtraneousValues: true });
+    return plainToClass(ShareCompleteDTO, partial, {
+      excludeExtraneousValues: true,
+    });
   }
 
   fromList(partial: Partial<ShareCompleteDTO>[]) {

--- a/backend/src/share/guard/shareSecurity.guard.ts
+++ b/backend/src/share/guard/shareSecurity.guard.ts
@@ -9,8 +9,8 @@ import * as moment from "moment";
 import { PrismaService } from "src/prisma/prisma.service";
 import { ShareService } from "src/share/share.service";
 import { ConfigService } from "src/config/config.service";
-import { JwtGuard } from 'src/auth/guard/jwt.guard';
-import { User } from '@prisma/client';
+import { JwtGuard } from "src/auth/guard/jwt.guard";
+import { User } from "@prisma/client";
 
 @Injectable()
 export class ShareSecurityGuard extends JwtGuard {

--- a/backend/src/share/guard/shareSecurity.guard.ts
+++ b/backend/src/share/guard/shareSecurity.guard.ts
@@ -62,8 +62,10 @@ export class ShareSecurityGuard extends JwtGuard {
     await super.canActivate(context);
     const user = request.user as User;
 
-    // Deny non-public access and not reverse share creator access the share
-    if (!share.reverseShare?.publicAccess && share.creatorId !== user?.id)
+    // Only the creator and reverse share creator can access the reverse share if it's not public
+    if (share.reverseShare && !share.reverseShare.publicAccess
+      && share.creatorId !== user?.id
+      && share.reverseShare.creatorId !== user?.id)
       throw new ForbiddenException(
         "Only reverse share creator can access this share",
         "private_share",

--- a/backend/src/share/share.controller.ts
+++ b/backend/src/share/share.controller.ts
@@ -29,7 +29,7 @@ import { ShareOwnerGuard } from "./guard/shareOwner.guard";
 import { ShareSecurityGuard } from "./guard/shareSecurity.guard";
 import { ShareTokenSecurity } from "./guard/shareTokenSecurity.guard";
 import { ShareService } from "./share.service";
-import { ShareCompleteDTO } from './dto/shareComplete.dto';
+import { ShareCompleteDTO } from "./dto/shareComplete.dto";
 @Controller("shares")
 export class ShareController {
   constructor(

--- a/backend/src/share/share.controller.ts
+++ b/backend/src/share/share.controller.ts
@@ -29,6 +29,7 @@ import { ShareOwnerGuard } from "./guard/shareOwner.guard";
 import { ShareSecurityGuard } from "./guard/shareSecurity.guard";
 import { ShareTokenSecurity } from "./guard/shareTokenSecurity.guard";
 import { ShareService } from "./share.service";
+import { ShareCompleteDTO } from './dto/shareComplete.dto';
 @Controller("shares")
 export class ShareController {
   constructor(
@@ -86,7 +87,7 @@ export class ShareController {
   @UseGuards(CreateShareGuard, ShareOwnerGuard)
   async complete(@Param("id") id: string, @Req() request: Request) {
     const { reverse_share_token } = request.cookies;
-    return new ShareDTO().from(
+    return new ShareCompleteDTO().from(
       await this.shareService.complete(id, reverse_share_token),
     );
   }

--- a/backend/src/share/share.controller.ts
+++ b/backend/src/share/share.controller.ts
@@ -29,7 +29,7 @@ import { ShareOwnerGuard } from "./guard/shareOwner.guard";
 import { ShareSecurityGuard } from "./guard/shareSecurity.guard";
 import { ShareTokenSecurity } from "./guard/shareTokenSecurity.guard";
 import { ShareService } from "./share.service";
-import { ShareCompleteDTO } from "./dto/shareComplete.dto";
+import { CompletedShareDTO } from "./dto/shareComplete.dto";
 @Controller("shares")
 export class ShareController {
   constructor(
@@ -87,7 +87,7 @@ export class ShareController {
   @UseGuards(CreateShareGuard, ShareOwnerGuard)
   async complete(@Param("id") id: string, @Req() request: Request) {
     const { reverse_share_token } = request.cookies;
-    return new ShareCompleteDTO().from(
+    return new CompletedShareDTO().from(
       await this.shareService.complete(id, reverse_share_token),
     );
   }

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -159,12 +159,12 @@ export class ShareService {
       );
     }
 
-    const isSendEmailToReverseShareCreator = share.reverseShare
+    const notifyReverseShareCreator = share.reverseShare
       ? this.config.get("smtp.enabled") &&
         share.reverseShare.sendEmailNotification
       : undefined;
 
-    if (isSendEmailToReverseShareCreator) {
+    if (notifyReverseShareCreator) {
       await this.emailService.sendMailToReverseShareCreator(
         share.reverseShare.creator.email,
         share.id,
@@ -188,7 +188,7 @@ export class ShareService {
 
     return {
       ...updatedShare,
-      isSendEmailToReverseShareCreator,
+      notifyReverseShareCreator,
     };
   }
 

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -30,7 +30,7 @@ export class ShareService {
     private jwtService: JwtService,
     private reverseShareService: ReverseShareService,
     private clamScanService: ClamScanService,
-  ) { }
+  ) {}
 
   async create(share: CreateShareDTO, user?: User, reverseShareToken?: string) {
     if (!(await this.isShareIdAvailable(share.id)).isAvailable)
@@ -59,9 +59,9 @@ export class ShareService {
         this.config.get("share.maxExpiration") !== 0 &&
         (expiresNever ||
           parsedExpiration >
-          moment()
-            .add(this.config.get("share.maxExpiration"), "hours")
-            .toDate())
+            moment()
+              .add(this.config.get("share.maxExpiration"), "hours")
+              .toDate())
       ) {
         throw new BadRequestException(
           "Expiration date exceeds maximum expiration date",
@@ -159,13 +159,12 @@ export class ShareService {
       );
     }
 
-    const isSendEmailToReverseShareCreator = share.reverseShare ?
-      this.config.get("smtp.enabled") &&
-      share.reverseShare.sendEmailNotification : undefined;
+    const isSendEmailToReverseShareCreator = share.reverseShare
+      ? this.config.get("smtp.enabled") &&
+        share.reverseShare.sendEmailNotification
+      : undefined;
 
-    if (
-      isSendEmailToReverseShareCreator
-    ) {
+    if (isSendEmailToReverseShareCreator) {
       await this.emailService.sendMailToReverseShareCreator(
         share.reverseShare.creator.email,
         share.id,

--- a/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
+++ b/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
@@ -61,6 +61,7 @@ const Body = ({
       sendEmailNotification: false,
       expiration_num: 1,
       expiration_unit: "-days",
+      simplified: false,
     },
   });
 
@@ -91,6 +92,7 @@ const Body = ({
         values.maxShareSize,
         values.maxUseCount,
         values.sendEmailNotification,
+        values.simplified
       )
       .then(({ link }) => {
         modals.closeAll();
@@ -210,6 +212,17 @@ const Body = ({
               })}
             />
           )}
+          <Switch
+              mt="xs"
+              labelPosition="left"
+              label={t("account.reverseShares.modal.simplified")}
+              description={t(
+                "account.reverseShares.modal.simplified.description",
+              )}
+              {...form.getInputProps("simplified", {
+                type: "checkbox",
+              })}
+            />
 
           <Button mt="md" type="submit">
             <FormattedMessage id="common.button.create" />

--- a/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
+++ b/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
@@ -22,6 +22,8 @@ import { getExpirationPreview } from "../../../utils/date.util";
 import toast from "../../../utils/toast.util";
 import FileSizeInput from "../FileSizeInput";
 import showCompletedReverseShareModal from "./showCompletedReverseShareModal";
+import { getCookie, setCookie } from 'cookies-next';
+
 
 const showCreateReverseShareModal = (
   modals: ModalsContextProps,
@@ -61,12 +63,16 @@ const Body = ({
       sendEmailNotification: false,
       expiration_num: 1,
       expiration_unit: "-days",
-      simplified: false,
-      publicAccess: true,
+      simplified: !!(getCookie('reverse-share.simplified') ?? false),
+      publicAccess: !!(getCookie('reverse-share.public-access') ?? true),
     },
   });
 
   const onSubmit = form.onSubmit(async (values) => {
+    // remember simplified and publicAccess in cookies
+    setCookie('reverse-share.simplified', values.simplified);
+    setCookie('reverse-share.public-access', values.publicAccess);
+
     const expirationDate = moment().add(
       form.values.expiration_num,
       form.values.expiration_unit.replace(

--- a/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
+++ b/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
@@ -62,6 +62,7 @@ const Body = ({
       expiration_num: 1,
       expiration_unit: "-days",
       simplified: false,
+      publicAccess: true,
     },
   });
 
@@ -92,7 +93,8 @@ const Body = ({
         values.maxShareSize,
         values.maxUseCount,
         values.sendEmailNotification,
-        values.simplified
+        values.simplified,
+        values.publicAccess,
       )
       .then(({ link }) => {
         modals.closeAll();
@@ -213,17 +215,27 @@ const Body = ({
             />
           )}
           <Switch
-              mt="xs"
-              labelPosition="left"
-              label={t("account.reverseShares.modal.simplified")}
-              description={t(
-                "account.reverseShares.modal.simplified.description",
-              )}
-              {...form.getInputProps("simplified", {
-                type: "checkbox",
-              })}
-            />
-
+            mt="xs"
+            labelPosition="left"
+            label={t("account.reverseShares.modal.simplified")}
+            description={t(
+              "account.reverseShares.modal.simplified.description",
+            )}
+            {...form.getInputProps("simplified", {
+              type: "checkbox",
+            })}
+          />
+          <Switch
+            mt="xs"
+            labelPosition="left"
+            label={t("account.reverseShares.modal.public-access")}
+            description={t(
+              "account.reverseShares.modal.public-access.description",
+            )}
+            {...form.getInputProps("publicAccess", {
+              type: "checkbox",
+            })}
+          />
           <Button mt="md" type="submit">
             <FormattedMessage id="common.button.create" />
           </Button>

--- a/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
+++ b/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
@@ -22,8 +22,7 @@ import { getExpirationPreview } from "../../../utils/date.util";
 import toast from "../../../utils/toast.util";
 import FileSizeInput from "../FileSizeInput";
 import showCompletedReverseShareModal from "./showCompletedReverseShareModal";
-import { getCookie, setCookie } from 'cookies-next';
-
+import { getCookie, setCookie } from "cookies-next";
 
 const showCreateReverseShareModal = (
   modals: ModalsContextProps,
@@ -63,15 +62,15 @@ const Body = ({
       sendEmailNotification: false,
       expiration_num: 1,
       expiration_unit: "-days",
-      simplified: !!(getCookie('reverse-share.simplified') ?? false),
-      publicAccess: !!(getCookie('reverse-share.public-access') ?? true),
+      simplified: !!(getCookie("reverse-share.simplified") ?? false),
+      publicAccess: !!(getCookie("reverse-share.public-access") ?? true),
     },
   });
 
   const onSubmit = form.onSubmit(async (values) => {
     // remember simplified and publicAccess in cookies
-    setCookie('reverse-share.simplified', values.simplified);
-    setCookie('reverse-share.public-access', values.publicAccess);
+    setCookie("reverse-share.simplified", values.simplified);
+    setCookie("reverse-share.public-access", values.publicAccess);
 
     const expirationDate = moment().add(
       form.values.expiration_num,

--- a/frontend/src/components/upload/modals/showCompletedUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCompletedUploadModal.tsx
@@ -7,12 +7,12 @@ import { FormattedMessage } from "react-intl";
 import useTranslate, {
   translateOutsideContext,
 } from "../../../hooks/useTranslate.hook";
-import { ShareForComplete } from "../../../types/share.type";
+import { CompletedShare } from "../../../types/share.type";
 import CopyTextField from "../CopyTextField";
 
 const showCompletedUploadModal = (
   modals: ModalsContextProps,
-  share: ShareForComplete,
+  share: CompletedShare,
   appUrl: string,
 ) => {
   const t = translateOutsideContext();
@@ -25,13 +25,7 @@ const showCompletedUploadModal = (
   });
 };
 
-const Body = ({
-  share,
-  appUrl,
-}: {
-  share: ShareForComplete;
-  appUrl: string;
-}) => {
+const Body = ({ share, appUrl }: { share: CompletedShare; appUrl: string }) => {
   const modals = useModals();
   const router = useRouter();
   const t = useTranslate();
@@ -41,7 +35,7 @@ const Body = ({
   return (
     <Stack align="stretch">
       <CopyTextField link={link} />
-      {share.isSendEmailToReverseShareCreator === true && (
+      {share.notifyReverseShareCreator === true && (
         <Text
           size="sm"
           sx={(theme) => ({

--- a/frontend/src/components/upload/modals/showCompletedUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCompletedUploadModal.tsx
@@ -45,7 +45,7 @@ const Body = ({ share, appUrl }: { share: CompletedShare; appUrl: string }) => {
                 : theme.colors.dark[4],
           })}
         >
-          {t("upload.modal.completed.send-email-to-reverse-share-creator")}
+          {t("upload.modal.completed.notified-reverse-share-creator")}
         </Text>
       )}
       <Text

--- a/frontend/src/components/upload/modals/showCompletedUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCompletedUploadModal.tsx
@@ -25,7 +25,13 @@ const showCompletedUploadModal = (
   });
 };
 
-const Body = ({ share, appUrl }: { share: ShareForComplete; appUrl: string }) => {
+const Body = ({
+  share,
+  appUrl,
+}: {
+  share: ShareForComplete;
+  appUrl: string;
+}) => {
   const modals = useModals();
   const router = useRouter();
   const t = useTranslate();
@@ -39,11 +45,14 @@ const Body = ({ share, appUrl }: { share: ShareForComplete; appUrl: string }) =>
         <Text
           size="sm"
           sx={(theme) => ({
-            color: theme.colorScheme === "dark"
-              ? theme.colors.gray[3]
-              : theme.colors.dark[4],
+            color:
+              theme.colorScheme === "dark"
+                ? theme.colors.gray[3]
+                : theme.colors.dark[4],
           })}
-        >{t("upload.modal.completed.send-email-to-reverse-share-creator")}</Text>
+        >
+          {t("upload.modal.completed.send-email-to-reverse-share-creator")}
+        </Text>
       )}
       <Text
         size="xs"
@@ -55,8 +64,8 @@ const Body = ({ share, appUrl }: { share: ShareForComplete; appUrl: string }) =>
         {moment(share.expiration).unix() === 0
           ? t("upload.modal.completed.never-expires")
           : t("upload.modal.completed.expires-on", {
-            expiration: moment(share.expiration).format("LLL"),
-          })}
+              expiration: moment(share.expiration).format("LLL"),
+            })}
       </Text>
 
       <Button

--- a/frontend/src/components/upload/modals/showCompletedUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCompletedUploadModal.tsx
@@ -35,11 +35,13 @@ const Body = ({ share, appUrl }: { share: ShareForComplete; appUrl: string }) =>
   return (
     <Stack align="stretch">
       <CopyTextField link={link} />
-      { share.isSendEmailToReverseShareCreator === true && (
+      {share.isSendEmailToReverseShareCreator === true && (
         <Text
           size="sm"
           sx={(theme) => ({
-            color: theme.colors.dark[4],
+            color: theme.colorScheme === "dark"
+              ? theme.colors.gray[3]
+              : theme.colors.dark[4],
           })}
         >{t("upload.modal.completed.send-email-to-reverse-share-creator")}</Text>
       )}
@@ -53,8 +55,8 @@ const Body = ({ share, appUrl }: { share: ShareForComplete; appUrl: string }) =>
         {moment(share.expiration).unix() === 0
           ? t("upload.modal.completed.never-expires")
           : t("upload.modal.completed.expires-on", {
-              expiration: moment(share.expiration).format("LLL"),
-            })}
+            expiration: moment(share.expiration).format("LLL"),
+          })}
       </Text>
 
       <Button

--- a/frontend/src/components/upload/modals/showCompletedUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCompletedUploadModal.tsx
@@ -7,12 +7,12 @@ import { FormattedMessage } from "react-intl";
 import useTranslate, {
   translateOutsideContext,
 } from "../../../hooks/useTranslate.hook";
-import { Share } from "../../../types/share.type";
+import { ShareForComplete } from "../../../types/share.type";
 import CopyTextField from "../CopyTextField";
 
 const showCompletedUploadModal = (
   modals: ModalsContextProps,
-  share: Share,
+  share: ShareForComplete,
   appUrl: string,
 ) => {
   const t = translateOutsideContext();
@@ -25,7 +25,7 @@ const showCompletedUploadModal = (
   });
 };
 
-const Body = ({ share, appUrl }: { share: Share; appUrl: string }) => {
+const Body = ({ share, appUrl }: { share: ShareForComplete; appUrl: string }) => {
   const modals = useModals();
   const router = useRouter();
   const t = useTranslate();
@@ -35,6 +35,14 @@ const Body = ({ share, appUrl }: { share: Share; appUrl: string }) => {
   return (
     <Stack align="stretch">
       <CopyTextField link={link} />
+      { share.isSendEmailToReverseShareCreator === true && (
+        <Text
+          size="sm"
+          sx={(theme) => ({
+            color: theme.colors.dark[4],
+          })}
+        >{t("upload.modal.completed.send-email-to-reverse-share-creator")}</Text>
+      )}
       <Text
         size="xs"
         sx={(theme) => ({

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -31,7 +31,7 @@ import { FileUpload } from "../../../types/File.type";
 import { CreateShare } from "../../../types/share.type";
 import { getExpirationPreview } from "../../../utils/date.util";
 import React from "react";
-import toast from '../../../utils/toast.util';
+import toast from "../../../utils/toast.util";
 
 const showCreateUploadModal = (
   modals: ModalsContextProps,
@@ -59,7 +59,7 @@ const showCreateUploadModal = (
           uploadCallback={uploadCallback}
         />
       ),
-    })
+    });
   }
 
   return modals.openModal({
@@ -74,9 +74,10 @@ const showCreateUploadModal = (
   });
 };
 
-const generateLink = () => Buffer.from(Math.random().toString(), "utf8")
-  .toString("base64")
-  .substring(10, 17);
+const generateLink = () =>
+  Buffer.from(Math.random().toString(), "utf8")
+    .toString("base64")
+    .substring(10, 17);
 
 const generateAvailableLink = async (times = 10): Promise<string> => {
   if (times <= 0) {
@@ -231,12 +232,7 @@ const CreateUploadModalBody = ({
             <Button
               style={{ flex: "0 0 auto" }}
               variant="outline"
-              onClick={() =>
-                form.setFieldValue(
-                  "link",
-                  generateLink(),
-                )
-              }
+              onClick={() => form.setFieldValue("link", generateLink())}
             >
               <FormattedMessage id="common.button.generate" />
             </Button>

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -483,15 +483,6 @@ const SimplifiedCreateUploadModalModal = ({
       .transform((value) => value || undefined)
       .min(3, t("common.error.too-short", { length: 3 }))
       .max(30, t("common.error.too-long", { length: 30 })),
-    password: yup
-      .string()
-      .transform((value) => value || undefined)
-      .min(3, t("common.error.too-short", { length: 3 }))
-      .max(30, t("common.error.too-long", { length: 30 })),
-    maxViews: yup
-      .number()
-      .transform((value) => value || undefined)
-      .min(1),
   });
 
   const form = useForm({

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -521,7 +521,7 @@ const SimplifiedCreateUploadModalModal = ({
   });
 
   return (
-    <>
+    <Stack>
       {showNotSignedInAlert && !options.isUserSignedIn && (
         <Alert
           withCloseButton
@@ -556,7 +556,7 @@ const SimplifiedCreateUploadModalModal = ({
           </Button>
         </Stack>
       </form>
-    </>
+    </Stack>
   );
 };
 

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -201,11 +201,11 @@ export default {
 
   "account.reverseShares.modal.simplified": "Simple mode",
   "account.reverseShares.modal.simplified.description":
-    "Make it easy for the person uploading the file to share it with you. They will not be able to customize the share link and additional security options.",
+    "Make it easy for the person uploading the file to share it with you. They will be able to customize only the name and description of the share.",
 
   "account.reverseShares.modal.public-access": "Public access",
   "account.reverseShares.modal.public-access.description":
-    "Anyone who knows the share link can access this shared file. When this switch is on, the file uploader can share their link with anyone.",
+    "Make the created shares with this reverse share public. If disabled only you can view the created shares.",
 
   "account.reverseShares.modal.max-use.label": "Max uses",
   "account.reverseShares.modal.max-use.description":
@@ -350,7 +350,7 @@ export default {
   "upload.modal.completed.expires-on":
     "This share will expire on {expiration}.",
   "upload.modal.completed.share-ready": "Share ready",
-  "upload.modal.completed.send-email-to-reverse-share-creator": "We have already sent the shared link to the creator of the Reverse Share via email. You can also manually share this link with them through other means.",
+  "upload.modal.completed.send-email-to-reverse-share-creator": "We have notified the creator of the reverse share. You can also manually share this link with them through other means.",
 
   // END /upload
 

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -199,6 +199,10 @@ export default {
   "account.reverseShares.modal.send-email.description":
     "Send an email notification when a share is created with this reverse share link.",
 
+  "account.reverseShares.modal.simplified": "Simple Mode",
+  "account.reverseShares.modal.simplified.description":
+    "Make it easy for the person uploading the file to share it with you. They will not be able to customize the share link and additional security options.",
+
   "account.reverseShares.modal.max-use.label": "Max uses",
   "account.reverseShares.modal.max-use.description":
     "The maximum amount of times this URL can be used to create a share.",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -199,9 +199,13 @@ export default {
   "account.reverseShares.modal.send-email.description":
     "Send an email notification when a share is created with this reverse share link.",
 
-  "account.reverseShares.modal.simplified": "Simple Mode",
+  "account.reverseShares.modal.simplified": "Simple mode",
   "account.reverseShares.modal.simplified.description":
     "Make it easy for the person uploading the file to share it with you. They will not be able to customize the share link and additional security options.",
+
+  "account.reverseShares.modal.public-access": "Public access",
+  "account.reverseShares.modal.public-access.description":
+    "Anyone who knows the share link can access this shared file. When this switch is on, the file uploader can share their link with anyone.",
 
   "account.reverseShares.modal.max-use.label": "Max uses",
   "account.reverseShares.modal.max-use.description":
@@ -360,6 +364,8 @@ export default {
   "share.error.not-found.title": "Share not found",
   "share.error.not-found.description":
     "The share you're looking for doesn't exist.",
+  "share.error.access-denied.title": "Private share",
+  "share.error.access-denied.description": "The current account does not have permission to access this share",
 
   "share.modal.password.title": "Password required",
   "share.modal.password.description":

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -346,6 +346,7 @@ export default {
   "upload.modal.completed.expires-on":
     "This share will expire on {expiration}.",
   "upload.modal.completed.share-ready": "Share ready",
+  "upload.modal.completed.send-email-to-reverse-share-creator": "We have already sent the shared link to the creator of the Reverse Share via email. You can also manually share this link with them through other means.",
 
   // END /upload
 

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -205,7 +205,7 @@ export default {
 
   "account.reverseShares.modal.public-access": "Public access",
   "account.reverseShares.modal.public-access.description":
-    "Make the created shares with this reverse share public. If disabled only you can view the created shares.",
+    "Make the created shares with this reverse share public. If disabled, only you and the creator of the share can view it.",
 
   "account.reverseShares.modal.max-use.label": "Max uses",
   "account.reverseShares.modal.max-use.description":
@@ -350,7 +350,7 @@ export default {
   "upload.modal.completed.expires-on":
     "This share will expire on {expiration}.",
   "upload.modal.completed.share-ready": "Share ready",
-  "upload.modal.completed.send-email-to-reverse-share-creator": "We have notified the creator of the reverse share. You can also manually share this link with them through other means.",
+  "upload.modal.completed.notified-reverse-share-creator": "We have notified the creator of the reverse share. You can also manually share this link with them through other means.",
 
   // END /upload
 

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -152,6 +152,9 @@ export default {
   "account.reverseShares.modal.max-size.label": "共享文件上限",
   "account.reverseShares.modal.send-email": "发送邮件提醒",
   "account.reverseShares.modal.send-email.description": "当这个预留共享链接被用于共享时，发送邮件提醒",
+  "account.reverseShares.modal.simplified": "简单模式",
+  "account.reverseShares.modal.simplified.description":
+    "让对方更简单快速地分享文件给你，对方将不能自定义分享的链接和额外的安全选项。",
   "account.reverseShares.modal.max-use.label": "最大使用次数",
   "account.reverseShares.modal.max-use.description": "这个预留共享链接可被用于创建共享的最大使用次数",
   "account.reverseShare.never-expires": "这个预留共享永不过期",

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -154,10 +154,10 @@ export default {
   "account.reverseShares.modal.send-email.description": "当这个预留共享链接被用于共享时，发送邮件提醒",
   "account.reverseShares.modal.simplified": "简单模式",
   "account.reverseShares.modal.simplified.description":
-    "让对方更简单快速地分享文件给你，对方将不能自定义分享的链接和额外的安全选项。",
+    "让上传者更轻松地与你共享文件，他们仅能自定义共享的名称和描述。",
   "account.reverseShares.modal.public-access": "公开访问",
   "account.reverseShares.modal.public-access.description":
-    "知道共享链接的任何人都可以访问这个共享文件，打开此项后，文件上传者可以将他的共享链接分享给任何人。",
+    "让通过这个反向共享创建共享能被公开访问。如果禁用，将只有您能够访问。",
   "account.reverseShares.modal.max-use.label": "最大使用次数",
   "account.reverseShares.modal.max-use.description": "这个预留共享链接可被用于创建共享的最大使用次数",
   "account.reverseShare.never-expires": "这个预留共享永不过期",
@@ -261,7 +261,7 @@ export default {
   "upload.modal.completed.never-expires": "这个共享永不过期",
   "upload.modal.completed.expires-on": "这个共享将过期于 {expiration}.",
   "upload.modal.completed.share-ready": "共享创建完毕",
-  "upload.modal.completed.send-email-to-reverse-share-creator": "我们已经通过电子邮件将共享链接发送给预留共享的创建者。您也可以通过其他方式将该链接手动分享给他们。",
+  "upload.modal.completed.send-email-to-reverse-share-creator": "我们已经通知预留共享的创建者。您也可以通过其他方式将该链接手动分享给他们。",
   // END /upload
   // /share/[id]
   "share.title": "共享 {shareId}",

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -157,7 +157,7 @@ export default {
     "让上传者更轻松地与你共享文件，他们仅能自定义共享的名称和描述。",
   "account.reverseShares.modal.public-access": "公开访问",
   "account.reverseShares.modal.public-access.description":
-    "让通过这个反向共享创建共享能被公开访问。如果禁用，将只有您能够访问。",
+    "让通过这个预留共享创建共享能被公开访问。如果禁用，将只有您和创建者能够访问。",
   "account.reverseShares.modal.max-use.label": "最大使用次数",
   "account.reverseShares.modal.max-use.description": "这个预留共享链接可被用于创建共享的最大使用次数",
   "account.reverseShare.never-expires": "这个预留共享永不过期",
@@ -261,7 +261,7 @@ export default {
   "upload.modal.completed.never-expires": "这个共享永不过期",
   "upload.modal.completed.expires-on": "这个共享将过期于 {expiration}.",
   "upload.modal.completed.share-ready": "共享创建完毕",
-  "upload.modal.completed.send-email-to-reverse-share-creator": "我们已经通知预留共享的创建者。您也可以通过其他方式将该链接手动分享给他们。",
+  "upload.modal.completed.notified-reverse-share-creator": "我们已经通知预留共享的创建者。您也可以通过其他方式将该链接手动分享给他们。",
   // END /upload
   // /share/[id]
   "share.title": "共享 {shareId}",

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -155,6 +155,9 @@ export default {
   "account.reverseShares.modal.simplified": "简单模式",
   "account.reverseShares.modal.simplified.description":
     "让对方更简单快速地分享文件给你，对方将不能自定义分享的链接和额外的安全选项。",
+  "account.reverseShares.modal.public-access": "公开访问",
+  "account.reverseShares.modal.public-access.description":
+    "知道共享链接的任何人都可以访问这个共享文件，打开此项后，文件上传者可以将他的共享链接分享给任何人。",
   "account.reverseShares.modal.max-use.label": "最大使用次数",
   "account.reverseShares.modal.max-use.description": "这个预留共享链接可被用于创建共享的最大使用次数",
   "account.reverseShare.never-expires": "这个预留共享永不过期",
@@ -268,6 +271,8 @@ export default {
   "share.error.removed.title": "共享已删除",
   "share.error.not-found.title": "共享未找到",
   "share.error.not-found.description": "共享文件走丢了",
+  "share.error.access-denied.title": "私有共享",
+  "share.error.access-denied.description": "当前账户没有权限访问此共享",
   "share.modal.password.title": "需要密码",
   "share.modal.password.description": "请输入密码来访问此共享",
   "share.modal.password": "密码",

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -258,6 +258,7 @@ export default {
   "upload.modal.completed.never-expires": "这个共享永不过期",
   "upload.modal.completed.expires-on": "这个共享将过期于 {expiration}.",
   "upload.modal.completed.share-ready": "共享创建完毕",
+  "upload.modal.completed.send-email-to-reverse-share-creator": "我们已经通过电子邮件将共享链接发送给预留共享的创建者。您也可以通过其他方式将该链接手动分享给他们。",
   // END /upload
   // /share/[id]
   "share.title": "共享 {shareId}",

--- a/frontend/src/pages/share/[shareId]/edit.tsx
+++ b/frontend/src/pages/share/[shareId]/edit.tsx
@@ -43,6 +43,12 @@ const Share = ({ shareId }: { shareId: string }) => {
               t("share.error.not-found.description"),
             );
           }
+        } else if (e.response.status == 403 && error == "share_removed") {
+          showErrorModal(
+            modals,
+            t("share.error.access-denied.title"),
+            t("share.error.access-denied.description"),
+          );
         } else {
           showErrorModal(modals, t("common.error"), t("common.error.unknown"));
         }

--- a/frontend/src/pages/share/[shareId]/index.tsx
+++ b/frontend/src/pages/share/[shareId]/index.tsx
@@ -75,8 +75,7 @@ const Share = ({ shareId }: { shareId: string }) => {
             t("share.error.access-denied.title"),
             t("share.error.access-denied.description"),
           );
-        }
-        else if (error == "share_password_required") {
+        } else if (error == "share_password_required") {
           showEnterPasswordModal(modals, getShareToken);
         } else if (error == "share_token_required") {
           getShareToken();

--- a/frontend/src/pages/share/[shareId]/index.tsx
+++ b/frontend/src/pages/share/[shareId]/index.tsx
@@ -69,7 +69,14 @@ const Share = ({ shareId }: { shareId: string }) => {
               "go-home",
             );
           }
-        } else if (error == "share_password_required") {
+        } else if (e.response.status == 403 && error == "private_share") {
+          showErrorModal(
+            modals,
+            t("share.error.access-denied.title"),
+            t("share.error.access-denied.description"),
+          );
+        }
+        else if (error == "share_password_required") {
           showEnterPasswordModal(modals, getShareToken);
         } else if (error == "share_token_required") {
           getShareToken();

--- a/frontend/src/pages/upload/[reverseShareToken].tsx
+++ b/frontend/src/pages/upload/[reverseShareToken].tsx
@@ -40,7 +40,13 @@ const Share = ({ reverseShareToken }: { reverseShareToken: string }) => {
 
   if (isLoading) return <LoadingOverlay visible />;
 
-  return <Upload isReverseShare maxShareSize={maxShareSize} simplified={simplified} />;
+  return (
+    <Upload
+      isReverseShare
+      maxShareSize={maxShareSize}
+      simplified={simplified}
+    />
+  );
 };
 
 export default Share;

--- a/frontend/src/pages/upload/[reverseShareToken].tsx
+++ b/frontend/src/pages/upload/[reverseShareToken].tsx
@@ -17,12 +17,14 @@ const Share = ({ reverseShareToken }: { reverseShareToken: string }) => {
   const [isLoading, setIsLoading] = useState(true);
 
   const [maxShareSize, setMaxShareSize] = useState(0);
+  const [simplified, setSimplified] = useState(false);
 
   useEffect(() => {
     shareService
       .setReverseShare(reverseShareToken)
       .then((reverseShareTokenData) => {
         setMaxShareSize(parseInt(reverseShareTokenData.maxShareSize));
+        setSimplified(reverseShareTokenData.simplified);
         setIsLoading(false);
       })
       .catch(() => {
@@ -38,7 +40,7 @@ const Share = ({ reverseShareToken }: { reverseShareToken: string }) => {
 
   if (isLoading) return <LoadingOverlay visible />;
 
-  return <Upload isReverseShare maxShareSize={maxShareSize} />;
+  return <Upload isReverseShare maxShareSize={maxShareSize} simplified={simplified} />;
 };
 
 export default Share;

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -25,9 +25,11 @@ let createdShare: Share;
 const Upload = ({
   maxShareSize,
   isReverseShare = false,
+  simplified
 }: {
   maxShareSize?: number;
   isReverseShare: boolean;
+  simplified: boolean
 }) => {
   const modals = useModals();
   const t = useTranslate();
@@ -133,6 +135,7 @@ const Upload = ({
         ),
         enableEmailRecepients: config.get("email.enableShareEmailRecipients"),
         maxExpirationInHours: config.get("share.maxExpiration"),
+        simplified,
       },
       files,
       uploadFiles,

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -25,11 +25,11 @@ let createdShare: Share;
 const Upload = ({
   maxShareSize,
   isReverseShare = false,
-  simplified
+  simplified,
 }: {
   maxShareSize?: number;
   isReverseShare: boolean;
-  simplified: boolean
+  simplified: boolean;
 }) => {
   const modals = useModals();
   const t = useTranslate();

--- a/frontend/src/services/share.service.ts
+++ b/frontend/src/services/share.service.ts
@@ -110,6 +110,7 @@ const createReverseShare = async (
   maxUseCount: number,
   sendEmailNotification: boolean,
   simplified: boolean,
+  publicAccess: boolean,
 ) => {
   return (
     await api.post("reverseShares", {
@@ -118,6 +119,7 @@ const createReverseShare = async (
       maxUseCount,
       sendEmailNotification,
       simplified,
+      publicAccess,
     })
   ).data;
 };

--- a/frontend/src/services/share.service.ts
+++ b/frontend/src/services/share.service.ts
@@ -109,6 +109,7 @@ const createReverseShare = async (
   maxShareSize: number,
   maxUseCount: number,
   sendEmailNotification: boolean,
+  simplified: boolean,
 ) => {
   return (
     await api.post("reverseShares", {
@@ -116,6 +117,7 @@ const createReverseShare = async (
       maxShareSize: maxShareSize.toString(),
       maxUseCount,
       sendEmailNotification,
+      simplified,
     })
   ).data;
 };

--- a/frontend/src/types/share.type.ts
+++ b/frontend/src/types/share.type.ts
@@ -11,6 +11,15 @@ export type Share = {
   hasPassword: boolean;
 };
 
+export type ShareForComplete = Share & {
+  /**
+   * undefined means is not reverse share
+   * true means server was send email to reverse share creator
+   * false means server was not send email to reverse share creator
+   * */
+  isSendEmailToReverseShareCreator: boolean | undefined;
+};
+
 export type CreateShare = {
   id: string;
   name?: string;

--- a/frontend/src/types/share.type.ts
+++ b/frontend/src/types/share.type.ts
@@ -11,13 +11,13 @@ export type Share = {
   hasPassword: boolean;
 };
 
-export type ShareForComplete = Share & {
+export type CompletedShare = Share & {
   /**
    * undefined means is not reverse share
    * true means server was send email to reverse share creator
    * false means server was not send email to reverse share creator
    * */
-  isSendEmailToReverseShareCreator: boolean | undefined;
+  notifyReverseShareCreator: boolean | undefined;
 };
 
 export type CreateShare = {


### PR DESCRIPTION
https://github.com/stonith404/pingvin-share/assets/30215105/27be9ed7-0c4b-4755-b6e4-d50b57ba41a6

The above is the effect currently achieved.

I have encountered some issues:

1. When creating a reverse share, if the recipient has already enabled email notifications, I would like to add a message in the "Share ready" dialog box to inform the uploader: "The system has notified the recipient to check the file. You can also copy the share link above to inform them." <br />This is my personal suggestion, and I would like to know if you think this prompt should be added. If you agree with this small prompt, perhaps we can expose the ReverseShare.sendEmailNotification field to determine the specific prompt text.

2. I believe that files shared via reverse sharing should only be visible to the creator of the reverse share. Additionally, since I have removed the password option in the simplified interface, should we restrict the visibility of shares created through reverse sharing to only ReverseShare.creator and Share.creator?

@stonith404 

