### PR TITLE
chore: sanitize appUrl to remove trailing slash

### DIFF
--- a/frontend/src/pages/admin/config/[category].tsx
+++ b/frontend/src/pages/admin/config/[category].tsx
@@ -72,6 +72,10 @@ export default function AppShellDemo() {
   };
 
   const updateConfigVariable = (configVariable: UpdateConfig) => {
+    if (configVariable.key === 'general.appUrl') {
+      configVariable.value = sanitizeUrl(configVariable.value);
+    }
+
     const index = updatedConfigVariables.findIndex(
       (item) => item.key === configVariable.key,
     );
@@ -84,6 +88,10 @@ export default function AppShellDemo() {
     } else {
       setUpdatedConfigVariables([...updatedConfigVariables, configVariable]);
     }
+  };
+
+  const sanitizeUrl = (url: string): string => {
+    return url.endsWith('/') ? url.slice(0, -1) : url;
   };
 
   useEffect(() => {


### PR DESCRIPTION
### chore: sanitize appUrl to remove trailing slash

### Description
I encountered an issue where the `appUrl` configuration would sometimes end with a trailing slash, such as `http://localhost:3000//s/c4MDgxM`. This PR addresses the issue by sanitizing the `appUrl` to ensure it does not end with a trailing slash before it is saved.

### Changes Made
- Added `sanitizeUrl` function to remove the trailing slash from URLs.
- Updated `updateConfigVariable` function to sanitize `appUrl` before updating the state.
