### PR TITLE
Worked on issue Feature Add email recipients more efficiently issue #500

### DIFF
--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -347,7 +347,8 @@ const CreateUploadModalBody = ({
                     placeholder={t("upload.modal.accordion.email.placeholder")}
                     searchable
                     creatable
-                    autoComplete="email-recipients"
+                    autoComplete="email"
+                    type="email"
                     getCreateLabel={(query) => `+ ${query}`}
                     onCreate={(query) => {
                       if (!query.match(/^\S+@\S+\.\S+$/)) {

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -368,9 +368,12 @@ const CreateUploadModalBody = ({
                     }}
                     {...form.getInputProps("recipients")}
                     onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                      // Add email on comma or semicolon
                       if (e.key === "," || e.key === ";") {
                         e.preventDefault();
-                        const inputValue = (e.target as HTMLInputElement).value.trim();
+                        const inputValue = (
+                          e.target as HTMLInputElement
+                        ).value.trim();
                         if (inputValue.match(/^\S+@\S+\.\S+$/)) {
                           form.setFieldValue("recipients", [
                             ...form.values.recipients,
@@ -383,9 +386,7 @@ const CreateUploadModalBody = ({
                         (e.target as HTMLInputElement).value = "";
                       }
                     }}
-
                   />
-
                 </Accordion.Panel>
               </Accordion.Item>
             )}

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -30,6 +30,7 @@ import shareService from "../../../services/share.service";
 import { FileUpload } from "../../../types/File.type";
 import { CreateShare } from "../../../types/share.type";
 import { getExpirationPreview } from "../../../utils/date.util";
+import React from "react";
 
 const showCreateUploadModal = (
   modals: ModalsContextProps,
@@ -56,6 +57,10 @@ const showCreateUploadModal = (
       />
     ),
   });
+};
+
+const handleInputChange = (event: any) => {
+  console.log("Input changed:", event);
 };
 
 const CreateUploadModalBody = ({
@@ -242,7 +247,6 @@ const CreateUploadModalBody = ({
                     disabled={form.values.never_expires}
                     {...form.getInputProps("expiration_unit")}
                     data={[
-                      // Set the label to singular if the number is 1, else plural
                       {
                         value: "-minutes",
                         label:
@@ -347,6 +351,7 @@ const CreateUploadModalBody = ({
                     placeholder={t("upload.modal.accordion.email.placeholder")}
                     searchable
                     creatable
+                    id="recipient_email"
                     autoComplete="email"
                     type="email"
                     getCreateLabel={(query) => `+ ${query}`}
@@ -366,7 +371,25 @@ const CreateUploadModalBody = ({
                       }
                     }}
                     {...form.getInputProps("recipients")}
+                    onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                      if (e.key === "," || e.key === ";") {
+                        e.preventDefault();
+                        const inputValue = (e.target as HTMLInputElement).value.trim();
+                        if (inputValue.match(/^\S+@\S+\.\S+$/)) {
+                          form.setFieldValue("recipients", [
+                            ...form.values.recipients,
+                            inputValue,
+                          ]);
+                          (e.target as HTMLInputElement).value = "";
+                        }
+                      } else if (e.key === " ") {
+                        e.preventDefault();
+                        (e.target as HTMLInputElement).value = "";
+                      }
+                    }}
+
                   />
+
                 </Accordion.Panel>
               </Accordion.Item>
             )}

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -59,10 +59,6 @@ const showCreateUploadModal = (
   });
 };
 
-const handleInputChange = (event: any) => {
-  console.log("Input changed:", event);
-};
-
 const CreateUploadModalBody = ({
   uploadCallback,
   files,


### PR DESCRIPTION
### Feature: Add email recipients more efficiently
### Check the screen recording for review
Fixes issue #500
### What was requested 
**1. Use Gmail-esque email form, which automatically submit an email address when typing the , (comma) symbol, so users can manually type in multiple email addresses without clicking the dropdown box all the time.
2. Use type="email" in the email form, and let the browser auto-detects a valid email address, and submit the form if the browser allows to.**
### Fix
**Implemented functionality where typing a comma followed by a space automatically submits the email address. This mirrors the common practice of typing out multiple items separated by commas.**
### Description of how it works
**After adding an email, if the user presses a comma followed by a space (e.g., exampleEmail@gmail.com, exampleEmail1@gmail.com), the email will be added to the recipient list and the input box will clear. This allows users to add multiple email addresses seamlessly without dealing with a cluttered input box**
https://github.com/stonith404/pingvin-share/assets/119395914/80581546-a56b-4fc1-9036-2161fac32973
