### PR TITLE
Update email.service.ts to allow unauthorized mail server certificates

### DIFF
--- a/backend/src/email/email.service.ts
+++ b/backend/src/email/email.service.ts
@@ -25,6 +25,10 @@ export class EmailService {
         user: this.config.get("smtp.username"),
         pass: this.config.get("smtp.password"),
       },
+      tls: {
+        // Do not fail on invalid certs
+        rejectUnauthorized: this.config.get("smtp.port") != 25
+      }
     });
   }
 


### PR DESCRIPTION
Allow unauthorized mail server certificates if mail server port is 25. Usefull for self hosted internal mail servers like MS Exchange Server.