### PR TITLE
Adjust docker compose

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   clamav:
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: stonith404/pingvin-share
     restart: unless-stopped
     ports:
-      - 3000:3000
+      - 3333:3333
     volumes:
       - "./data:/opt/app/backend/data"
       - "./data/images:/opt/app/frontend/public/img"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   pingvin-share:
     image: stonith404/pingvin-share

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: stonith404/pingvin-share
     restart: unless-stopped
     ports:
-      - 3333:3333
+      - 3000:3000
     volumes:
       - "./data:/opt/app/backend/data"
       - "./data/images:/opt/app/frontend/public/img"


### PR DESCRIPTION
Very minor changes:
1. The compose `version` tag hasn't been necessary for a while now: https://docs.docker.com/compose/compose-file/04-version-and-name/
2. changed the default port in the compose file to the one provided by Next.js 14.2.3 when starting a new v.0.26.0 container
```
Attaching to pingvin-discord-pingvin-1
pingvin-discord-pingvin-1  | cp: can't create '/opt/app/frontend/public/img/favicon.ico': No such file or directory
pingvin-discord-pingvin-1  | cp: can't create directory '/opt/app/frontend/public/img/icons': No such file or directory
pingvin-discord-pingvin-1  | cp: can't create '/opt/app/frontend/public/img/logo.png': No such file or directory
pingvin-discord-pingvin-1  |   ▲ Next.js 14.2.3
pingvin-discord-pingvin-1  |   - Local:        http://localhost:3333
pingvin-discord-pingvin-1  |   - Network:      http://0.0.0.0:3333
pingvin-discord-pingvin-1  |
pingvin-discord-pingvin-1  |
pingvin-discord-pingvin-1  |  ✓ Starting...
...
```