### PR TITLE
Bug Fix: Get Started Button on Home Page not working when Sign-Up is disabled

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -77,6 +77,7 @@ export default function Home() {
   const config = useConfig();
   const [signupEnabled, setSignupEnabled] = useState(true);
 
+  // If user is already authenticated, redirect to the upload page
   useEffect(() => {
     refreshUser().then((user) => {
       if (user) {
@@ -84,6 +85,7 @@ export default function Home() {
       }
     });
 
+    // If registration is disabled, get started button should redirect to the sign in page
     try {
       const allowRegistration = config.get("share.allowRegistration");
       setSignupEnabled(allowRegistration !== false);

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -10,12 +10,13 @@ import {
 } from "@mantine/core";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { TbCheck } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
 import Logo from "../components/Logo";
 import Meta from "../components/Meta";
 import useUser from "../hooks/user.hook";
+import useConfig from "../hooks/config.hook";
 
 const useStyles = createStyles((theme) => ({
   inner: {
@@ -73,15 +74,27 @@ export default function Home() {
   const { classes } = useStyles();
   const { refreshUser } = useUser();
   const router = useRouter();
+  const config = useConfig();
+  const [signupEnabled, setSignupEnabled] = useState(true);
 
-  // If the user is already logged in, redirect to the upload page
   useEffect(() => {
     refreshUser().then((user) => {
       if (user) {
         router.replace("/upload");
       }
     });
-  }, []);
+
+    try {
+      const allowRegistration = config.get("share.allowRegistration");
+      setSignupEnabled(allowRegistration !== false);
+    } catch (error) {
+      setSignupEnabled(true);
+    }
+  }, [config]);
+
+  const getButtonHref = () => {
+    return signupEnabled ? "/auth/signUp" : "/auth/signIn";
+  };
 
   return (
     <>
@@ -142,12 +155,15 @@ export default function Home() {
             <Group mt={30}>
               <Button
                 component={Link}
-                href="/auth/signUp"
+                href={getButtonHref()}
                 radius="xl"
                 size="md"
                 className={classes.control}
               >
-                <FormattedMessage id="home.button.start" />
+                <FormattedMessage 
+                  id="home.button.start"
+                  defaultMessage="Get started"
+                />
               </Button>
               <Button
                 component={Link}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -164,7 +164,6 @@ export default function Home() {
               >
                 <FormattedMessage 
                   id="home.button.start"
-                  defaultMessage="Get started"
                 />
               </Button>
               <Button


### PR DESCRIPTION
PR fixes deadlink on "Get Started" button when allow registration is disabled. When registration is disabled, the "Get Started" button on the home page will now link to the signin page. #557 