### PR TITLE
feat(email): add {email} placeholder to user invitation email

### DIFF
--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -107,7 +107,7 @@ const configVariables: ConfigVariables = {
     inviteMessage: {
       type: "text",
       defaultValue:
-        "Hey!\n\nYou were invited to Pingvin Share. Click this link to accept the invite: {url}\n\nYour password is: {password}\n\nPingvin Share 🐧",
+        'Hey!\n\nYou were invited to Pingvin Share. Click this link to accept the invite: {url}\n\nYou can use the email "{email}" and the password "{password}" to sign in.\n\nPingvin Share 🐧',
     },
   },
   smtp: {

--- a/backend/src/email/email.service.ts
+++ b/backend/src/email/email.service.ts
@@ -116,7 +116,8 @@ export class EmailService {
       this.config
         .get("email.inviteMessage")
         .replaceAll("{url}", loginUrl)
-        .replaceAll("{password}", password),
+        .replaceAll("{password}", password)
+        .replaceAll("{email}", recipientEmail),
     );
   }
 

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -446,7 +446,7 @@ export default {
     "Subject of the email which gets sent when an admin invites a user.",
   "admin.config.email.invite-message": "Invite message",
   "admin.config.email.invite-message.description":
-    "Message which gets sent when an admin invites a user. {url} will be replaced with the invite URL and {password} with the password.",
+    "Message which gets sent when an admin invites a user. {url} will be replaced with the invite URL, {email} with the email and {password} with the password of the user.",
 
   "admin.config.share.allow-registration": "Allow registration",
   "admin.config.share.allow-registration.description":


### PR DESCRIPTION
Thanks for this project! Some users were confused about their username when receiving invitations, so I added a placeholder in the invitation email to specify the username along with the password. 

Note: Translations will need to be updated to include this placeholder description.

Let me know if any further changes are needed.