### PR TITLE
Remove env line and add comment about update-env

### DIFF
--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -39,6 +39,6 @@ docker compose up -d
    cd ../frontend
    npm install
    npm run build
-   API_URL=http://localhost:8080 # Set the URL of the backend, default: http://localhost:8080
    pm2 restart pingvin-share-frontend
    ```
+Note that environemnt variables are not picked up when using pm2 restart, if you actually want to change configs, you need to run ````pm2 --update-env restart````


### PR DESCRIPTION
the update guide mentions setting the API_URL environment variable, this is not necessary and has no effect since pm2 keeps the environment in the task and reuses it

