### PR TITLE
feat(oauth): Option to logout from OpenID Connect provider

### DIFF
--- a/backend/prisma/migrations/20241007181823_oauth_id_token/migration.sql
+++ b/backend/prisma/migrations/20241007181823_oauth_id_token/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "RefreshToken" ADD COLUMN "oauthIDToken" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -40,6 +40,8 @@ model RefreshToken {
 
   userId String
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  oauthIDToken  String? // prefixed with the ID of the issuing OAuth provider, separated by a colon
 }
 
 model LoginToken {

--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -275,6 +275,10 @@ const configVariables: ConfigVariables = {
       type: "string",
       defaultValue: "",
     },
+    "oidc-signOut": {
+      type: "boolean",
+      defaultValue: "false",
+    },
     "oidc-usernameClaim": {
       type: "string",
       defaultValue: "",

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -172,10 +172,10 @@ export class AuthController {
     @Req() request: Request,
     @Res({ passthrough: true }) response: Response,
   ) {
-    await this.authService.signOut(request.cookies.access_token);
+    const redirectURI = await this.authService.signOut(request.cookies.access_token);
 
     const isSecure = this.config.get("general.appUrl").startsWith("https");
-    response.cookie("access_token", "accessToken", {
+    response.cookie("access_token", "", {
       maxAge: -1,
       secure: isSecure,
     });
@@ -185,6 +185,10 @@ export class AuthController {
       maxAge: -1,
       secure: isSecure,
     });
+
+    if (typeof redirectURI === "string") {
+      return { redirectURI: redirectURI.toString() };
+    }
   }
 
   @Post("totp/enable")

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { JwtModule } from "@nestjs/jwt";
 import { EmailModule } from "src/email/email.module";
 import { AuthController } from "./auth.controller";
@@ -7,6 +7,7 @@ import { AuthTotpService } from "./authTotp.service";
 import { JwtStrategy } from "./strategy/jwt.strategy";
 import { LdapService } from "./ldap.service";
 import { UserModule } from "../user/user.module";
+import { OAuthModule } from "../oauth/oauth.module";
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { UserModule } from "../user/user.module";
       global: true,
     }),
     EmailModule,
+    forwardRef(() => OAuthModule),
     UserModule,
   ],
   controllers: [AuthController],

--- a/backend/src/oauth/dto/oauthSignIn.dto.ts
+++ b/backend/src/oauth/dto/oauthSignIn.dto.ts
@@ -4,4 +4,5 @@ export interface OAuthSignInDto {
   providerUsername: string;
   email: string;
   isAdmin?: boolean;
+  idToken?: string;
 }

--- a/backend/src/oauth/oauth.module.ts
+++ b/backend/src/oauth/oauth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { OAuthController } from "./oauth.controller";
 import { OAuthService } from "./oauth.service";
 import { AuthModule } from "../auth/auth.module";
@@ -51,6 +51,7 @@ import { MicrosoftProvider } from "./provider/microsoft.provider";
       inject: ["OAUTH_PROVIDERS"],
     },
   ],
-  imports: [AuthModule],
+  imports: [forwardRef(() => AuthModule)],
+  exports: [OAuthService],
 })
 export class OAuthModule {}

--- a/backend/src/oauth/provider/discord.provider.ts
+++ b/backend/src/oauth/provider/discord.provider.ts
@@ -91,6 +91,7 @@ export class DiscordProvider implements OAuthProvider<DiscordToken> {
       providerId: user.id,
       providerUsername: user.global_name ?? user.username,
       email: user.email,
+      idToken: `discord:${token.idToken}`,
     };
   }
 

--- a/backend/src/oauth/provider/genericOidc.provider.ts
+++ b/backend/src/oauth/provider/genericOidc.provider.ts
@@ -197,6 +197,7 @@ export abstract class GenericOidcProvider implements OAuthProvider<OidcToken> {
       providerId: idTokenData.sub,
       providerUsername: username,
       ...(isAdmin !== undefined && { isAdmin }),
+      idToken: `${this.name}:${token.idToken}`,
     };
   }
 
@@ -251,6 +252,8 @@ export interface OidcConfiguration {
   id_token_signing_alg_values_supported: string[];
   scopes_supported?: string[];
   claims_supported?: string[];
+  frontchannel_logout_supported?: boolean;
+  end_session_endpoint?: string;
 }
 
 export interface OidcJwk {

--- a/backend/src/oauth/provider/github.provider.ts
+++ b/backend/src/oauth/provider/github.provider.ts
@@ -61,6 +61,7 @@ export class GitHubProvider implements OAuthProvider<GitHubToken> {
       providerId: user.id.toString(),
       providerUsername: user.name ?? user.login,
       email,
+      idToken: `github:${token.idToken}`,
     };
   }
 

--- a/frontend/src/i18n/translations/de-DE.ts
+++ b/frontend/src/i18n/translations/de-DE.ts
@@ -392,6 +392,8 @@ export default {
   "admin.config.oauth.oidc-enabled.description": "OpenID Connect Anmeldung erlaubt",
   "admin.config.oauth.oidc-discovery-uri": "OpenID Verbindung Discovery URL",
   "admin.config.oauth.oidc-discovery-uri.description": "Discovery-URL der OpenID OAuth App",
+  "admin.config.oauth.oidc-sign-out": "Abmelden von OpenID Connect",
+  "admin.config.oauth.oidc-sign-out.description": "Wenn aktiviert, wird der Benutzer mit der „Abmelden“-Schaltfläche vom OpenID-Connect-Provider abgemeldet.",
   "admin.config.oauth.oidc-username-claim": "OpenID Connect Benutzername anfordern",
   "admin.config.oauth.oidc-username-claim.description": "Benutzername im OpenID Token. Leer lassen, wenn du nicht weißt, was diese Konfiguration bedeutet.",
   "admin.config.oauth.oidc-role-path": "Path to roles in OpenID Connect token",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -547,6 +547,9 @@ export default {
   "admin.config.oauth.oidc-discovery-uri": "OpenID Connect Discovery URI",
   "admin.config.oauth.oidc-discovery-uri.description":
     "Discovery URI of the OpenID Connect OAuth app",
+  "admin.config.oauth.oidc-sign-out": "Sign out from OpenID Connect",
+  "admin.config.oauth.oidc-sign-out.description":
+    "Whether the “Sign out” button will sign out from the OpenID Connect provider",
   "admin.config.oauth.oidc-username-claim": "OpenID Connect username claim",
   "admin.config.oauth.oidc-username-claim.description":
     "Username claim in OpenID Connect ID token. Leave it blank if you don't know what this config is.",

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -29,8 +29,10 @@ const signUp = async (email: string, username: string, password: string) => {
 };
 
 const signOut = async () => {
-  await api.post("/auth/signOut");
-  window.location.reload();
+  const response = await api.post("/auth/signOut");
+
+  if (URL.canParse(response.data?.redirectURI)) window.location.href = response.data.redirectURI;
+  else window.location.reload();
 };
 
 const refreshAccessToken = async () => {


### PR DESCRIPTION
* Fixes #598

Tested with Keycloak and the generic OpenID Connect provider configuration. 

It should be easy to extend the configurations of GitHub and Discord to support logout as well from here, but I never worked with those providers and don’t have a client configuration at hand for them. Feel free to test and extend.