### PR TITLE
fix(oauth): Add `post_logout_redirect_uri` to OAuth logout redirect URI

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -257,6 +257,7 @@ export class AuthService {
           const configuration =  await provider.getConfiguration();
           if (configuration.frontchannel_logout_supported && URL.canParse(configuration.end_session_endpoint)) {
             const redirectURI = new URL(configuration.end_session_endpoint);
+            redirectURI.searchParams.append("post_logout_redirect_uri", this.config.get("general.appUrl"));
             redirectURI.searchParams.append("id_token_hint", idTokenHint);
             redirectURI.searchParams.append("client_id", this.config.get(`oauth.${providerName}-clientId`));
             return redirectURI.toString();

--- a/docs/docs/setup/oauth2login.md
+++ b/docs/docs/setup/oauth2login.md
@@ -42,7 +42,9 @@ Redirect URL: `https://<your-domain>/api/oauth/callback/discord`
 
 Generic OpenID Connect provider is also supported, we have tested it on Keycloak, Authentik and Casdoor.
 
-Redirect URL: `https://<your-domain>/api/oauth/callback/oidc`
+Redirect URI: `https://<your-domain>/api/oauth/callback/oidc`
+
+Post Logout Redirect URI: `https://<your-domain>`
 
 ## Custom your OAuth 2 Provider
 


### PR DESCRIPTION
This is a small addition to #631. Apologies for not including it earlier.

Without it, the OpenID Connect provider shows a “You are now logged out – [Click here to go back to the application](https://pingvin-share.dev.eliasschneider.com)” confirmation page after logout. Adding the `post_logout_redirect_uri` parameter will cause the provider to perform the logout and immediately redirect back to Pingvin Share, reducing the number of user interactions and thereby streamlining the logout process.

This OpenID Connect feature is standardized [here](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RedirectionAfterLogout).