### PR TITLE
change his to their for describing user

### DIFF
--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -254,7 +254,7 @@ export default {
 
   "admin.users.edit.delete.title": "Delete user: {username} ?",
   "admin.users.edit.delete.description":
-    "Do you really want to delete this user and all his shares?",
+    "Do you really want to delete this user and all their shares?",
 
   // showCreateUserModal.tsx
   "admin.users.modal.create.title": "Create user",


### PR DESCRIPTION
we talked about addressing people in generic non-gender terms for the German translation, I looked through the English version first and noticed on gender-specific term assuming a user is "his"
