### PR TITLE
bug(file): downloading zip exceeding 4gb crashes app

### DIFF
--- a/backend/src/file/file.controller.ts
+++ b/backend/src/file/file.controller.ts
@@ -54,13 +54,14 @@ export class FileController {
     @Res({ passthrough: true }) res: Response,
     @Param("shareId") shareId: string,
   ) {
-    const zip = await this.fileService.getZip(shareId);
+    const zipStream = this.fileService.getZip(shareId);
+  
     res.set({
       "Content-Type": "application/zip",
       "Content-Disposition": contentDisposition(`${shareId}.zip`),
     });
 
-    return new StreamableFile(zip);
+    return new StreamableFile(zipStream);
   }
 
   @Get(":fileId")

--- a/backend/src/file/file.service.ts
+++ b/backend/src/file/file.service.ts
@@ -61,7 +61,7 @@ export class FileService {
 
   getZip(shareId: string) {
     const storageService = this.getStorageService();
-    return this.streamToUint8Array(storageService.getZip(shareId) as Readable);
+    return storageService.getZip(shareId) as Readable;
   }
 
   private async streamToUint8Array(stream: Readable): Promise<Uint8Array> {


### PR DESCRIPTION
Hello! This is my first time contributing to an open source software, and it's also my first time working with nest, so please let me know if I'm not following best practices!

This PR fixes https://github.com/stonith404/pingvin-share/issues/708

This bug occurs because the ZIP file size exceeds the maximum buffer size that Node.js can handle in a single chunk.

I have removed the buffer conversion that was causing this bug, so that we directly return the readable stream from the storage service.

I have tested locally for shares larger than 4gb, and it doesn't crash now. The function `streamToUint8Array` is now unused, but I'm not sure if it will be used in the future, so I've left it in for now. 