### PR TITLE
docs: fix some typos

### DIFF
--- a/docs/docs/help-out/contribute.md
+++ b/docs/docs/help-out/contribute.md
@@ -23,7 +23,7 @@ Before you submit the pull request for review please ensure that
   When `TYPE` can be:
 
   - **feat** - is a new feature
-  - **doc** - documentation only changes
+  - **docs** - documentation only changes
   - **fix** - a bug fix
   - **refactor** - code change that neither fixes a bug nor adds a feature
 

--- a/docs/docs/setup/integrations.md
+++ b/docs/docs/setup/integrations.md
@@ -8,7 +8,7 @@ id: integrations
 
 ClamAV is used to scan shares for malicious files and remove them if found.
 
-Please note that ClamAV needs a lot of [ressources](https://docs.clamav.net/manual/Installing/Docker.html#memory-ram-requirements).
+Please note that ClamAV needs a lot of [resources](https://docs.clamav.net/manual/Installing/Docker.html#memory-ram-requirements).
 
 ### Docker
 

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -46,4 +46,4 @@ docker compose up -d
    npm run build
    pm2 restart pingvin-share-frontend
    ```
-Note that environemnt variables are not picked up when using pm2 restart, if you actually want to change configs, you need to run ````pm2 --update-env restart````
+Note that environment variables are not picked up when using pm2 restart, if you actually want to change configs, you need to run ````pm2 --update-env restart````


### PR DESCRIPTION
I changed "doc" to "docs" in `contribute.md` as I could only find the latter commit type in the commit history.