### PR TITLE
Fix: Update build action and add labels to image for Renovate Bot support

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -43,11 +43,12 @@ jobs:
           password:  ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
This is to (hopefully?) fix that the docker images have no labels. especially for ```"org.opencontainers.image.source":``` which is needed for [renovate bot](https://docs.renovatebot.com/modules/datasource/docker/) to be able to pull the Release notes for the image.

When running ```docker inspect ghcr.io/stonith404/pingvin-share:v1.10.1``` the image does not seem to have any labels, compared to for example ESPHome which has the following labels (for 2025.2.0):
```yaml
"Labels": {
                "org.opencontainers.image.authors": "The ESPHome Authors",
                "org.opencontainers.image.description": "ESPHome is a system to configure your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems",
                "org.opencontainers.image.documentation": "https://esphome.io/",
                "org.opencontainers.image.licenses": "ESPHome",
                "org.opencontainers.image.source": "https://github.com/esphome/esphome",
                "org.opencontainers.image.title": "ESPHome",
                "org.opencontainers.image.url": "https://esphome.io/",
                "org.opencontainers.image.version": "2025.2.0"
            }
```

From [looking at the metadata action](https://github.com/docker/metadata-action) you just add "labels" to build and push and reference the labels from meta-step.

Also updated the docker hub login step to v3, same as used for GitHub login.