### PR TITLE
feat(s3): allow disabling upload checksum

### DIFF
--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -349,6 +349,10 @@ export const configVariables = {
       defaultValue: "",
       obscured: true,
     },
+    useChecksum: {
+      type: "boolean",
+      defaultValue: "true",
+    },
   },
   legal: {
     enabled: {

--- a/backend/src/file/s3.service.ts
+++ b/backend/src/file/s3.service.ts
@@ -275,6 +275,8 @@ export class S3FileService {
   }
 
   getS3Instance(): S3Client {
+    const checksumCalculation = this.config.get("s3.useChecksum") === true ? null : "WHEN_REQUIRED";
+
     return new S3Client({
       endpoint: this.config.get("s3.endpoint"),
       region: this.config.get("s3.region"),
@@ -283,6 +285,8 @@ export class S3FileService {
         secretAccessKey: this.config.get("s3.secret"),
       },
       forcePathStyle: true,
+      requestChecksumCalculation: checksumCalculation,
+      responseChecksumValidation: checksumCalculation,
     });
   }
 

--- a/frontend/src/i18n/translations/cs-CZ.ts
+++ b/frontend/src/i18n/translations/cs-CZ.ts
@@ -465,6 +465,8 @@ export default {
   "admin.config.s3.key.description": "The key which allows you to access the S3 bucket.",
   "admin.config.s3.secret": "Secret",
   "admin.config.s3.secret.description": "The secret which allows you to access the S3 bucket.",
+  "admin.config.s3.use-checksum": "Použít checksum",
+  "admin.config.s3.use-checksum.description": "Vypněte pro backendy které nepodporují checksum (např. B2)",
   "admin.config.category.legal": "Legal",
   "admin.config.legal.enabled": "Enable legal notices",
   "admin.config.legal.enabled.description": "Whether to show a link to imprint and privacy policy in the footer.",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -655,6 +655,8 @@ export default {
   "admin.config.s3.key.description": "The key which allows you to access the S3 bucket.",
   "admin.config.s3.secret": "Secret",
   "admin.config.s3.secret.description": "The secret which allows you to access the S3 bucket.",
+  "admin.config.s3.use-checksum": "Use checksum",
+  "admin.config.s3.use-checksum.description": "Turn off for backends that does not support checkum (eg. B2)",
 
   "admin.config.category.legal": "Legal",
   "admin.config.legal.enabled": "Enable legal notices",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -656,7 +656,7 @@ export default {
   "admin.config.s3.secret": "Secret",
   "admin.config.s3.secret.description": "The secret which allows you to access the S3 bucket.",
   "admin.config.s3.use-checksum": "Use checksum",
-  "admin.config.s3.use-checksum.description": "Turn off for backends that does not support checkum (eg. B2)",
+  "admin.config.s3.use-checksum.description": "Turn off for backends that do not support checksum (e.g. B2).",
 
   "admin.config.category.legal": "Legal",
   "admin.config.legal.enabled": "Enable legal notices",


### PR DESCRIPTION
Adds a S3 config option to disable upload checksums. Allows use of Backblaze B2 backend which does not support `x-amz-checksum-*` headers (rejects it as hard error).

Relates to https://github.com/stonith404/pingvin-share/issues/798, https://github.com/stonith404/pingvin-share/issues/788

Tested it against Backblaze B2 and its working.