### PR TITLE
fix(s3): format path when bucket path is '/'

### DIFF
--- a/backend/src/file/s3.service.ts
+++ b/backend/src/file/s3.service.ts
@@ -55,13 +55,24 @@ export class S3FileService {
       throw new BadRequestException("Invalid file ID format");
     }
 
+    if (!shareId || shareId.includes("/")) {
+      throw new BadRequestException("Invalid share ID format");
+    }
+
+    if (!file.name || file.name.includes("..")) {
+      throw new BadRequestException("Invalid file name");
+    }
+
     const buffer = Buffer.from(data, "base64");
     const key = `${this.getS3Path()}${shareId}/${file.name}`;
     const bucketName = this.config.get("s3.bucketName");
     const s3Instance = this.getS3Instance();
 
+    this.logger.debug(
+      `Processing chunk ${chunk.index + 1}/${chunk.total} for file "${key}"`,
+    );
+
     try {
-      // Initialize multipart upload if it's the first chunk
       if (chunk.index === 0) {
         const multipartInitResponse = await s3Instance.send(
           new CreateMultipartUploadCommand({
@@ -75,15 +86,18 @@ export class S3FileService {
           throw new Error("Failed to initialize multipart upload.");
         }
 
-        // Store the uploadId and parts list in memory
         this.multipartUploads[file.id] = {
           uploadId,
           parts: [],
         };
+
+        this.logger.debug(
+          `Initialized multipart upload for "${key}" with uploadId "${uploadId}"`,
+        );
       }
 
-      // Get the ongoing multipart upload
       const multipartUpload = this.multipartUploads[file.id];
+
       if (!multipartUpload) {
         throw new InternalServerErrorException(
           "Multipart upload session not found.",
@@ -92,7 +106,6 @@ export class S3FileService {
 
       const uploadId = multipartUpload.uploadId;
 
-      // Upload the current chunk
       const partNumber = chunk.index + 1; // Part numbers start from 1
 
       const uploadPartResponse: UploadPartCommandOutput = await s3Instance.send(
@@ -105,13 +118,13 @@ export class S3FileService {
         }),
       );
 
-      // Store the ETag and PartNumber for later completion
       multipartUpload.parts.push({
         ETag: uploadPartResponse.ETag,
         PartNumber: partNumber,
       });
 
-      // Complete the multipart upload if it's the last chunk
+      this.logger.debug(`Uploaded part ${partNumber} for "${key}"`);
+
       if (chunk.index === chunk.total - 1) {
         await s3Instance.send(
           new CompleteMultipartUploadCommand({
@@ -124,12 +137,13 @@ export class S3FileService {
           }),
         );
 
-        // Remove the completed upload from memory
+        this.logger.debug(`Completed multipart upload for "${key}"`);
+
         delete this.multipartUploads[file.id];
       }
     } catch (error) {
-      // Abort the multipart upload if it fails
       const multipartUpload = this.multipartUploads[file.id];
+
       if (multipartUpload) {
         try {
           await s3Instance.send(
@@ -139,27 +153,60 @@ export class S3FileService {
               UploadId: multipartUpload.uploadId,
             }),
           );
+
+          this.logger.debug(`Aborted multipart upload for "${key}"`);
         } catch (abortError) {
-          console.error("Error aborting multipart upload:", abortError);
+          this.logger.error("Error aborting multipart upload", {
+            abortError,
+            key,
+          });
         }
         delete this.multipartUploads[file.id];
       }
-      this.logger.error(error);
-      throw new Error("Multipart upload failed. The upload has been aborted.");
+
+      this.logger.error("Error in multipart upload", {
+        error,
+        fileId: file.id,
+        fileName: file.name,
+        shareId,
+        key,
+        chunkIndex: chunk.index,
+        bucket: bucketName,
+      });
+      throw new InternalServerErrorException(
+        "Multipart upload failed. The upload has been aborted.",
+      );
     }
 
     const isLastChunk = chunk.index == chunk.total - 1;
-    if (isLastChunk) {
-      const fileSize: number = await this.getFileSize(shareId, file.name);
 
-      await this.prisma.file.create({
-        data: {
-          id: file.id,
-          name: file.name,
-          size: fileSize.toString(),
-          share: { connect: { id: shareId } },
-        },
-      });
+    if (isLastChunk) {
+      try {
+        const fileSize: number = await this.getFileSize(shareId, file.name);
+
+        await this.prisma.file.create({
+          data: {
+            id: file.id,
+            name: file.name,
+            size: fileSize.toString(),
+            share: { connect: { id: shareId } },
+          },
+        });
+
+        this.logger.debug(
+          `Created database record for file "${file.name}" with ID "${file.id}"`,
+        );
+      } catch (error) {
+        this.logger.error("Error creating file record", {
+          error,
+          fileId: file.id,
+          fileName: file.name,
+          shareId,
+        });
+        throw new InternalServerErrorException(
+          "Failed to create file record in database",
+        );
+      }
     }
 
     return file;
@@ -201,18 +248,43 @@ export class S3FileService {
 
     if (!fileMetaData) throw new NotFoundException("File not found");
 
+    if (!shareId || shareId.includes("/")) {
+      throw new BadRequestException("Invalid share ID format");
+    }
+
+    if (!fileMetaData.name || fileMetaData.name.includes("..")) {
+      throw new BadRequestException("Invalid file name");
+    }
+
     const key = `${this.getS3Path()}${shareId}/${fileMetaData.name}`;
+    const bucketName = this.config.get("s3.bucketName");
     const s3Instance = this.getS3Instance();
+
+    this.logger.debug(
+      `Attempting to delete file "${key}" from bucket "${bucketName}"`,
+    );
 
     try {
       await s3Instance.send(
         new DeleteObjectCommand({
-          Bucket: this.config.get("s3.bucketName"),
+          Bucket: bucketName,
           Key: key,
         }),
       );
+
+      this.logger.debug(
+        `Successfully deleted file "${key}" from bucket "${bucketName}"`,
+      );
     } catch (error) {
-      throw new Error("Could not delete file from S3");
+      this.logger.error("Error deleting file from S3", {
+        error,
+        shareId,
+        fileId,
+        fileName: fileMetaData.name,
+        key,
+        bucket: bucketName,
+      });
+      throw new InternalServerErrorException("Could not delete file from S3");
     }
 
     await this.prisma.file.delete({ where: { id: fileId } });
@@ -220,62 +292,127 @@ export class S3FileService {
 
   async deleteAllFiles(shareId: string) {
     const prefix = `${this.getS3Path()}${shareId}/`;
+    const bucketName = this.config.get("s3.bucketName");
     const s3Instance = this.getS3Instance();
 
+    this.logger.debug(
+      `Attempting to delete files with prefix "${prefix}" from bucket "${bucketName}"`,
+    );
+
     try {
-      // List all objects under the given prefix
+      if (!shareId || shareId.includes("/")) {
+        throw new BadRequestException("Invalid share ID format");
+      }
+
       const listResponse = await s3Instance.send(
         new ListObjectsV2Command({
-          Bucket: this.config.get("s3.bucketName"),
+          Bucket: bucketName,
           Prefix: prefix,
         }),
       );
 
+      this.logger.debug(
+        `ListObjectsV2Command response: Found ${listResponse.Contents?.length || 0} objects`,
+        { prefix, keyCount: listResponse.KeyCount },
+      );
+
       if (!listResponse.Contents || listResponse.Contents.length === 0) {
-        throw new Error(`No files found for share ${shareId}`);
+        this.logger.warn(
+          `No files found for share ${shareId} with prefix "${prefix}"`,
+        );
+
+        try {
+          const rootListResponse = await s3Instance.send(
+            new ListObjectsV2Command({
+              Bucket: bucketName,
+              Delimiter: "/",
+            }),
+          );
+
+          this.logger.debug(`Root level folders in bucket:`, {
+            prefixes: rootListResponse.CommonPrefixes?.map((p) => p.Prefix),
+            objects: rootListResponse.Contents?.map((c) => c.Key),
+          });
+        } catch (rootListError) {
+          this.logger.error(`Error listing root level folders`, {
+            error: rootListError,
+          });
+        }
+
+        return;
       }
 
-      // Extract the keys of the files to be deleted
       const objectsToDelete = listResponse.Contents.map((file) => ({
         Key: file.Key!,
       }));
 
-      // Delete all files in a single request (up to 1000 objects at once)
+      this.logger.debug(`Deleting ${objectsToDelete.length} objects`, {
+        firstFew: objectsToDelete.slice(0, 3).map((o) => o.Key),
+      });
+
       await s3Instance.send(
         new DeleteObjectsCommand({
-          Bucket: this.config.get("s3.bucketName"),
+          Bucket: bucketName,
           Delete: {
             Objects: objectsToDelete,
           },
         }),
       );
+
+      this.logger.debug(
+        `Successfully deleted ${objectsToDelete.length} files for share ${shareId}`,
+      );
     } catch (error) {
-      throw new Error("Could not delete all files from S3");
+      this.logger.error("Error deleting all files from S3", {
+        error,
+        shareId,
+        prefix,
+        bucket: bucketName,
+      });
+
+      throw new InternalServerErrorException(
+        "Could not delete all files from S3",
+      );
     }
   }
 
   async getFileSize(shareId: string, fileName: string): Promise<number> {
+    if (!shareId || shareId.includes("/")) {
+      throw new BadRequestException("Invalid share ID format");
+    }
+
+    if (!fileName || fileName.includes("..")) {
+      throw new BadRequestException("Invalid file name");
+    }
+
     const key = `${this.getS3Path()}${shareId}/${fileName}`;
+    const bucketName = this.config.get("s3.bucketName");
     const s3Instance = this.getS3Instance();
 
     try {
-      // Get metadata of the file using HeadObjectCommand
       const headObjectResponse = await s3Instance.send(
         new HeadObjectCommand({
-          Bucket: this.config.get("s3.bucketName"),
+          Bucket: bucketName,
           Key: key,
         }),
       );
 
-      // Return ContentLength which is the file size in bytes
       return headObjectResponse.ContentLength ?? 0;
     } catch (error) {
-      throw new Error("Could not retrieve file size");
+      this.logger.error("Error getting file size", {
+        error,
+        shareId,
+        fileName,
+        key,
+        bucket: bucketName,
+      });
+      throw new InternalServerErrorException("Could not retrieve file size");
     }
   }
 
   getS3Instance(): S3Client {
-    const checksumCalculation = this.config.get("s3.useChecksum") === true ? null : "WHEN_REQUIRED";
+    const checksumCalculation =
+      this.config.get("s3.useChecksum") === true ? null : "WHEN_REQUIRED";
 
     return new S3Client({
       endpoint: this.config.get("s3.endpoint"),
@@ -298,6 +435,10 @@ export class S3FileService {
 
   getS3Path(): string {
     const configS3Path = this.config.get("s3.bucketPath");
-    return configS3Path ? `${configS3Path}/` : "";
+
+    if (!configS3Path) return "";
+
+    const cleanPath = configS3Path.replace(/^\/+|\/+$/g, "");
+    return cleanPath ? `${cleanPath}/` : "";
   }
 }


### PR DESCRIPTION
This pull request enhances the `S3FileService` class by improving error handling, adding detailed logging, and validating inputs to ensure robustness and maintainability.

When trying the integration of Pingvin with Minio, I had the issue where the bucket content could not be deleted. I've added the path of the bucket as `/`, which caused an error in the backend while trying to delete the assets.

![image](https://github.com/user-attachments/assets/7ba801a2-a599-4952-ad07-2365d1227969)

The error message is also vague, so I added the error object and some debug messages to give a better context of what is happening under the hood:

Error thrown on main when trying to delete the bucket contents on a Minio server.

```bash
2025-04-23T22:54:08.017219025Z [Nest] 56  - 04/23/2025, 10:54:08 PM   ERROR ;5;3m[ExceptionsHandler] Could not delete all files from S3
2025-04-23T22:54:08.017276391Z Error: Could not delete all files from S3
2025-04-23T22:54:08.017279026Z     at S3FileService.deleteAllFiles (/opt/app/backend/dist/src/file/s3.service.js:177:19)
2025-04-23T22:54:08.017280779Z     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2025-04-23T22:54:08.017282423Z     at async ShareService.remove (/opt/app/backend/dist/src/share/share.service.js:236:9)
2025-04-23T22:54:08.017284346Z     at async ShareController.remove (/opt/app/backend/dist/src/share/share.controller.js:69:9)
```

After cloning and adding the error object to the error message:

```bash
{
  error: XMinioInvalidObjectName: Object name contains unsupported characters.
      at throwDefaultError (C:\Projetos\pingvin-share\backend\node_modules\@smithy\smithy-client\dist-cjs\index.js:867:20)        
      at C:\Projetos\pingvin-share\backend\node_modules\@smithy\smithy-client\dist-cjs\index.js:876:5
      at de_CommandError (C:\Projetos\pingvin-share\backend\node_modules\@aws-sdk\client-s3\dist-cjs\index.js:4952:14)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async C:\Projetos\pingvin-share\backend\node_modules\@smithy\middleware-serde\dist-cjs\index.js:35:20
      at async C:\Projetos\pingvin-share\backend\node_modules\@aws-sdk\middleware-sdk-s3\dist-cjs\index.js:484:18
      at async C:\Projetos\pingvin-share\backend\node_modules\@smithy\middleware-retry\dist-cjs\index.js:320:38
      at async C:\Projetos\pingvin-share\backend\node_modules\@aws-sdk\middleware-sdk-s3\dist-cjs\index.js:110:22
      at async C:\Projetos\pingvin-share\backend\node_modules\@aws-sdk\middleware-sdk-s3\dist-cjs\index.js:137:14
      at async C:\Projetos\pingvin-share\backend\node_modules\@aws-sdk\middleware-logger\dist-cjs\index.js:33:22 {
    '$fault': 'client',
    '$metadata': {
      httpStatusCode: 400,
      requestId: '18391315A583A4E6',
      extendedRequestId: 'dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8',
      cfId: undefined,
      attempts: 1,
      totalRetryDelay: 0
    },
    Code: 'XMinioInvalidObjectName',
    BucketName: 'mishare',
    Resource: '/mishare/',
    Region: 'eu-west',
    RequestId: '18391315A583A4E6',
    HostId: 'dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8'
  },
  shareId: 'Eo7pQuzW'
}
```

## Now

When uploading files to a s3 bucket:

```bash
[Nest] 15092  - 04/24/2025, 12:59:16 AM   DEBUG [S3FileService] Processing chunk 1/1 for file "vTnV6nMf/730_20240311181546_1.png"
[Nest] 15092  - 04/24/2025, 12:59:16 AM   DEBUG [S3FileService] Initialized multipart upload for "vTnV6nMf/730_20240311181546_1.png" with uploadId "ZDRhODY2OTAtZDExMS00MDhmLThmOWUtNjFlMGNjZmQxNDMxLmI2NDFkMGMyLWJkMGItNDRlZi05MmEwLWJkYWZhMTBlNmRiZHgxNzQ1NDQ5MTU2NDE3Mzk1NzE4"
[Nest] 15092  - 04/24/2025, 12:59:16 AM   DEBUG [S3FileService] Uploaded part 1 for "vTnV6nMf/730_20240311181546_1.png"
[Nest] 15092  - 04/24/2025, 12:59:16 AM   DEBUG [S3FileService] Completed multipart upload for "vTnV6nMf/730_20240311181546_1.png"
[Nest] 15092  - 04/24/2025, 12:59:16 AM   DEBUG [S3FileService] Created database record for file "730_20240311181546_1.png" with ID "1ee927dc-aa2b-480f-80cd-24afeaa8317e"
``` 

When deleting the shared content from pingvin:

```bash
[Nest] 15092  - 04/24/2025, 1:00:20 AM   DEBUG [S3FileService] Attempting to delete files with prefix "vTnV6nMf/" from bucket "mishare"
[Nest] 15092  - 04/24/2025, 1:00:20 AM   DEBUG [S3FileService] ListObjectsV2Command response: Found 1 objects
[Nest] 15092  - 04/24/2025, 1:00:20 AM   DEBUG [S3FileService] Object(2) {
  prefix: 'vTnV6nMf/',
  keyCount: 1
}
[Nest] 15092  - 04/24/2025, 1:00:20 AM   DEBUG [S3FileService] Deleting 1 objects
[Nest] 15092  - 04/24/2025, 1:00:20 AM   DEBUG [S3FileService] Object(1) {
  firstFew: [
    'vTnV6nMf/730_20240311181546_1.png'
  ]
}
[Nest] 15092  - 04/24/2025, 1:00:20 AM   DEBUG [S3FileService] Successfully deleted 1 files for share vTnV6nMf
```

