### PR TITLE
feat(s3): stream s3 content over a zip file

### DIFF
--- a/backend/src/file/file.controller.ts
+++ b/backend/src/file/file.controller.ts
@@ -9,6 +9,7 @@ import {
   Res,
   StreamableFile,
   UseGuards,
+  UseFilters,
 } from "@nestjs/common";
 import { SkipThrottle } from "@nestjs/throttler";
 import * as contentDisposition from "content-disposition";
@@ -18,6 +19,7 @@ import { ShareOwnerGuard } from "src/share/guard/shareOwner.guard";
 import { FileService } from "./file.service";
 import { FileSecurityGuard } from "./guard/fileSecurity.guard";
 import * as mime from "mime-types";
+import { StreamResponseFilter } from "./filter/stream-response.filter";
 
 @Controller("shares/:shareId/files")
 export class FileController {
@@ -50,11 +52,12 @@ export class FileController {
 
   @Get("zip")
   @UseGuards(FileSecurityGuard)
+  @UseFilters(StreamResponseFilter)
   async getZip(
     @Res({ passthrough: true }) res: Response,
     @Param("shareId") shareId: string,
   ) {
-    const zipStream = this.fileService.getZip(shareId);
+    const zipStream = await this.fileService.getZip(shareId);
 
     res.set({
       "Content-Type": "application/zip",

--- a/backend/src/file/file.module.ts
+++ b/backend/src/file/file.module.ts
@@ -6,11 +6,17 @@ import { FileController } from "./file.controller";
 import { FileService } from "./file.service";
 import { LocalFileService } from "./local.service";
 import { S3FileService } from "./s3.service";
+import { StreamResponseFilter } from "./filter/stream-response.filter";
 
 @Module({
   imports: [JwtModule.register({}), ReverseShareModule, ShareModule],
   controllers: [FileController],
-  providers: [FileService, LocalFileService, S3FileService],
+  providers: [
+    FileService,
+    LocalFileService,
+    S3FileService,
+    StreamResponseFilter,
+  ],
   exports: [FileService],
 })
 export class FileModule {}

--- a/backend/src/file/file.service.ts
+++ b/backend/src/file/file.service.ts
@@ -59,9 +59,9 @@ export class FileService {
     return storageService.deleteAllFiles(shareId);
   }
 
-  getZip(shareId: string) {
+  getZip(shareId: string): Promise<Readable> | Readable {
     const storageService = this.getStorageService();
-    return storageService.getZip(shareId) as Readable;
+    return storageService.getZip(shareId);
   }
 
   private async streamToUint8Array(stream: Readable): Promise<Uint8Array> {

--- a/backend/src/file/filter/stream-response.filter.ts
+++ b/backend/src/file/filter/stream-response.filter.ts
@@ -1,0 +1,39 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  Logger,
+} from "@nestjs/common";
+import { Request, Response } from "express";
+
+@Catch(HttpException)
+export class StreamResponseFilter implements ExceptionFilter {
+  private readonly logger = new Logger(StreamResponseFilter.name);
+
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    const status = exception.getStatus();
+
+    if (response.headersSent) {
+      this.logger.warn(
+        `Headers already sent - exception thrown during streaming. Path: ${request.url}, Status: ${status}`,
+      );
+
+      // The response has already started streaming, cannot send JSON error
+      // Just log the error and ensure the stream is properly terminated
+      response.end();
+      return;
+    }
+
+    // If headers not sent yet, handle normally with JSON response
+    response.status(status).json({
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+      message: exception.message,
+    });
+  }
+}

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -366,6 +366,8 @@ export default {
   // /share/[id]
   "share.title": "Share {shareId}",
   "share.description": "Look what I've shared with you!",
+  "share.fileCount":
+    "{count, plural, =1 {# file} other {# files}} · {size} (zip file may be smaller due to compression)",
   "share.error.visitor-limit-exceeded.title": "Visitor limit exceeded",
   "share.error.visitor-limit-exceeded.description":
     "The visitor limit from this share has been exceeded.",
@@ -408,14 +410,15 @@ export default {
   // /imprint
   "imprint.title": "Imprint",
   // END /imprint
-  
+
   // /privacy
   "privacy.title": "Privacy Policy",
   // END /privacy
 
   // /admin/config
   "admin.config.config-file-warning.title": "Configuration file present",
-  "admin.config.config-file-warning.description": "As you have a configured Pingvin Share with a configuration file, you can't change the configuration through the UI.",
+  "admin.config.config-file-warning.description":
+    "As you have a configured Pingvin Share with a configuration file, you can't change the configuration through the UI.",
 
   "admin.config.title": "Configuration",
   "admin.config.category.general": "General",
@@ -642,7 +645,8 @@ export default {
 
   "admin.config.category.s3": "S3",
   "admin.config.s3.enabled": "Enabled",
-  "admin.config.s3.enabled.description": "Whether S3 should be used to store the shared files instead of the local file system.",
+  "admin.config.s3.enabled.description":
+    "Whether S3 should be used to store the shared files instead of the local file system.",
   "admin.config.s3.endpoint": "Endpoint",
   "admin.config.s3.endpoint.description": "The URL of the S3 bucket.",
   "admin.config.s3.region": "Region",
@@ -650,25 +654,34 @@ export default {
   "admin.config.s3.bucket-name": "Bucket name",
   "admin.config.s3.bucket-name.description": "The name of the S3 bucket.",
   "admin.config.s3.bucket-path": "Path",
-  "admin.config.s3.bucket-path.description": "The default path which should be used to store the files in the S3 bucket.",
+  "admin.config.s3.bucket-path.description":
+    "The default path which should be used to store the files in the S3 bucket.",
   "admin.config.s3.key": "Key",
-  "admin.config.s3.key.description": "The key which allows you to access the S3 bucket.",
+  "admin.config.s3.key.description":
+    "The key which allows you to access the S3 bucket.",
   "admin.config.s3.secret": "Secret",
-  "admin.config.s3.secret.description": "The secret which allows you to access the S3 bucket.",
+  "admin.config.s3.secret.description":
+    "The secret which allows you to access the S3 bucket.",
   "admin.config.s3.use-checksum": "Use checksum",
-  "admin.config.s3.use-checksum.description": "Turn off for backends that do not support checksum (e.g. B2).",
+  "admin.config.s3.use-checksum.description":
+    "Turn off for backends that do not support checksum (e.g. B2).",
 
   "admin.config.category.legal": "Legal",
   "admin.config.legal.enabled": "Enable legal notices",
-  "admin.config.legal.enabled.description": "Whether to show a link to imprint and privacy policy in the footer.",
+  "admin.config.legal.enabled.description":
+    "Whether to show a link to imprint and privacy policy in the footer.",
   "admin.config.legal.imprint-text": "Imprint text",
-  "admin.config.legal.imprint-text.description": "The text which should be shown in the imprint. Supports Markdown. Leave blank to link to an external imprint page.",
+  "admin.config.legal.imprint-text.description":
+    "The text which should be shown in the imprint. Supports Markdown. Leave blank to link to an external imprint page.",
   "admin.config.legal.imprint-url": "Imprint URL",
-  "admin.config.legal.imprint-url.description": "If you already have an imprint page you can link it here instead of using the text field.",
+  "admin.config.legal.imprint-url.description":
+    "If you already have an imprint page you can link it here instead of using the text field.",
   "admin.config.legal.privacy-policy-text": "Privacy policy text",
-  "admin.config.legal.privacy-policy-text.description": "The text which should be shown in the privacy policy. Supports Markdown. Leave blank to link to an external privacy policy page.",
+  "admin.config.legal.privacy-policy-text.description":
+    "The text which should be shown in the privacy policy. Supports Markdown. Leave blank to link to an external privacy policy page.",
   "admin.config.legal.privacy-policy-url": "Privacy policy URL",
-  "admin.config.legal.privacy-policy-url.description": "If you already have a privacy policy page you can link it here instead of using the text field.",
+  "admin.config.legal.privacy-policy-url.description":
+    "If you already have a privacy policy page you can link it here instead of using the text field.",
 
   // 404
   "404.description": "Oops this page doesn't exist.",

--- a/frontend/src/pages/share/[shareId]/index.tsx
+++ b/frontend/src/pages/share/[shareId]/index.tsx
@@ -2,6 +2,7 @@ import { Box, Group, Text, Title } from "@mantine/core";
 import { useModals } from "@mantine/modals";
 import { GetServerSidePropsContext } from "next";
 import { useEffect, useState } from "react";
+import { FormattedMessage } from "react-intl";
 import Meta from "../../../components/Meta";
 import DownloadAllButton from "../../../components/share/DownloadAllButton";
 import FileList from "../../../components/share/FileList";
@@ -11,6 +12,7 @@ import useTranslate from "../../../hooks/useTranslate.hook";
 import shareService from "../../../services/share.service";
 import { Share as ShareType } from "../../../types/share.type";
 import toast from "../../../utils/toast.util";
+import { byteToHumanSizeString } from "../../../utils/fileSize.util";
 
 export function getServerSideProps(context: GetServerSidePropsContext) {
   return {
@@ -107,7 +109,25 @@ const Share = ({ shareId }: { shareId: string }) => {
         <Box style={{ maxWidth: "70%" }}>
           <Title order={3}>{share?.name || share?.id}</Title>
           <Text size="sm">{share?.description}</Text>
+          {share?.files?.length > 0 && (
+            <Text size="sm" color="dimmed" mt={5}>
+              <FormattedMessage
+                id="share.fileCount"
+                values={{
+                  count: share?.files?.length || 0,
+                  size: byteToHumanSizeString(
+                    share?.files?.reduce(
+                      (total: number, file: { size: string }) =>
+                        total + parseInt(file.size),
+                      0,
+                    ) || 0,
+                  ),
+                }}
+              />
+            </Text>
+          )}
         </Box>
+
         {share?.files.length > 1 && <DownloadAllButton shareId={shareId} />}
       </Group>
 

--- a/package.json
+++ b/package.json
@@ -11,5 +11,9 @@
   },
   "devDependencies": {
     "conventional-changelog-cli": "^3.0.0"
+  },
+  "prettier": {
+    "singleQuote": false,
+    "trailingComma": "all"
   }
 }


### PR DESCRIPTION
# Overview
This pull request introduces several enhancements and fixes across the backend and frontend of the project. The most significant changes include implementing ZIP file generation for S3 storage, adding a custom exception filter for streaming responses, updating the frontend to display file count and size information, and improving code formatting with Prettier configuration. 

https://github.com/user-attachments/assets/7e0a3f4e-e38f-420d-b45f-5c63fa79a239

Below is a categorized summary of the key changes:

### Backend Enhancements

* **ZIP File Support for S3**: Added a `getZip` method in `S3FileService` to generate ZIP files for files stored in S3. This method streams files from S3, compresses them using the `archiver` library, and handles errors gracefully.
* **Custom Exception Filter**: Introduced `StreamResponseFilter` to handle exceptions during streaming. If headers are already sent, the filter logs the error and terminates the stream; otherwise, it sends a JSON error response.
* **Controller Updates**: Applied the `StreamResponseFilter` to the `getZip` endpoint in `FileController` and updated the method to handle asynchronous ZIP file generation.

### Frontend Updates

* **File Count and Size Display**: Enhanced the share page to show the total number of files and their combined size using a new i18n key (`share.fileCount`) and the `byteToHumanSizeString` utility.