### PR TITLE
fix: Fix spelling mistake and add clarity in email template

### DIFF
--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -89,7 +89,7 @@ export const configVariables = {
     shareRecipientsMessage: {
       type: "text",
       defaultValue:
-        "Hey!\n\n{creator} ({creatorEmail}) shared some files with you, view or download the files with this link: {shareUrl}\n\nThe share will expire {expires}.\n\nNote: {desc}\n\nShared securely with Pingvin Share 🐧",
+        "Hey!\n\n{creator} ({creatorEmail}) shared some files with you. You can view or download the files with this link: {shareUrl}\n\nThe share will expire {expires}.\n\nNote: {desc}\n\nShared securely with Pingvin Share 🐧",
     },
     reverseShareSubject: {
       type: "string",

--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -107,7 +107,7 @@ export const configVariables = {
     resetPasswordMessage: {
       type: "text",
       defaultValue:
-        "Hey!\n\nYou requested a password reset. Click this link to reset your password: {url}\nThe link expires in a hour.\n\nPingvin Share 🐧",
+        "Hey!\n\nYou requested a password reset. Click this link to reset your password: {url}\nThe link expires in an hour.\n\nPingvin Share 🐧",
     },
     inviteSubject: {
       type: "string",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -45,7 +45,7 @@ email:
     Hey!
 
 
-    {creator} ({creatorEmail}) shared some files with you, view or download the
+    {creator} ({creatorEmail}) shared some files with you. You can view or download the
     files with this link: {shareUrl}
 
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -75,7 +75,7 @@ email:
     You requested a password reset. Click this link to reset your password:
     {url}
 
-    The link expires in a hour.
+    The link expires in an hour.
 
 
     Pingvin Share 🐧


### PR DESCRIPTION
- Change "in a hour" to "in an hour" in the default _Reset password message_ email template in files `config.example.yaml` and `config.seed.ts`.
- Change `... shared some files with you, view or download the files ...` to `... shared some files with you. You can view or download the files ...`. This adds more clarity on the specific call-to-action the recipient of the email.