### PR TITLE
feat(legal)-Company-Sharing-Policy

### DIFF
--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -380,6 +380,11 @@ export const configVariables = {
       defaultValue: "",
       secret: false,
     },
+    companySharingPolicy: {
+      type: "text",
+      defaultValue: "",
+      secret: false,
+    },
   },
 } satisfies ConfigVariables;
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -217,6 +217,8 @@ legal:
   privacyPolicyText: ""
   #If you already have a privacy policy page you can link it here instead of using the text field.
   privacyPolicyUrl: ""
+  #The text which should be shown in the company sharing policy. Supports Markdown. 
+  companySharingPolicy: ""
 #This configuration is used to create the initial user when the application is started for the first time.
 #Make sure to change at least the password as soon as you log in!
 initUser:

--- a/frontend/src/components/upload/Dropzone.tsx
+++ b/frontend/src/components/upload/Dropzone.tsx
@@ -38,8 +38,8 @@ const useStyles = createStyles((theme) => ({
     border: '1px dashed',
     borderWidth: 1,
     borderColor: theme.colorScheme === "dark"
-    ? '#373A40'
-    : '#ced4da',
+    ? theme.colors.dark[3]
+    : theme.colors.gray[3],
     borderRadius: 10,
     backgroundColor: theme.colorScheme === "dark"
     ? theme.colors.dark[4]
@@ -48,6 +48,7 @@ const useStyles = createStyles((theme) => ({
     textAlign: 'center',
     padding: 20,
   }
+
 }));
 
 const Dropzone = ({

--- a/frontend/src/components/upload/Dropzone.tsx
+++ b/frontend/src/components/upload/Dropzone.tsx
@@ -1,4 +1,5 @@
-import { Button, Center, createStyles, Group, Text } from "@mantine/core";
+import { Anchor, Button, Center, createStyles, Group, Paper, Text, useMantineTheme } from "@mantine/core";
+import Markdown from "markdown-to-jsx";
 import { Dropzone as MantineDropzone } from "@mantine/dropzone";
 import { ForwardedRef, useRef } from "react";
 import { TbCloudUpload, TbUpload } from "react-icons/tb";
@@ -7,6 +8,7 @@ import useTranslate from "../../hooks/useTranslate.hook";
 import { FileUpload } from "../../types/File.type";
 import { byteToHumanSizeString } from "../../utils/fileSize.util";
 import toast from "../../utils/toast.util";
+import useConfig from "../../hooks/config.hook";
 
 const useStyles = createStyles((theme) => ({
   wrapper: {
@@ -30,6 +32,22 @@ const useStyles = createStyles((theme) => ({
     position: "absolute",
     bottom: -20,
   },
+
+  companysharingpolicy: {
+    marginTop: 50,
+    border: '1px dashed',
+    borderWidth: 1,
+    borderColor: theme.colorScheme === "dark"
+    ? '#373A40'
+    : '#ced4da',
+    borderRadius: 10,
+    backgroundColor: theme.colorScheme === "dark"
+    ? theme.colors.dark[4]
+    : theme.colors.gray[1],
+    fontSize: 'small',
+    textAlign: 'center',
+    padding: 20,
+  }
 }));
 
 const Dropzone = ({
@@ -44,6 +62,12 @@ const Dropzone = ({
   onFilesChanged: (files: FileUpload[]) => void;
 }) => {
   const t = useTranslate();
+  const config = useConfig();
+  const { colorScheme } = useMantineTheme();
+  const hasCompanySharingPolicy = !!(
+    config.get("legal.companySharingPolicy")
+  );
+  const companySharingPolicy = config.get("legal.companySharingPolicy");
 
   const { classes } = useStyles();
   const openRef = useRef<() => void>();
@@ -88,6 +112,43 @@ const Dropzone = ({
               values={{ maxSize: byteToHumanSizeString(maxShareSize) }}
             />
           </Text>
+          {hasCompanySharingPolicy && (
+          <Group className={classes.companysharingpolicy}>
+            <Markdown
+              options={{
+                forceBlock: true,
+                overrides: {
+                  pre: {
+                    props: {
+                      style: {
+                        backgroundColor:
+                          colorScheme == "dark"
+                            ? "rgba(50, 50, 50, 0.5)"
+                            : "rgba(220, 220, 220, 0.5)",
+                        padding: "0.75em",
+                        whiteSpace: "pre-wrap",
+                      },
+                    },
+                  },
+                  table: {
+                    props: {
+                      className: "md",
+                    },
+                  },
+                  a: {
+                    props: {
+                      target: "_blank",
+                      rel: "noreferrer",
+                    },
+                    component: Anchor,
+                  },
+                },
+              }}
+            >
+              {companySharingPolicy}
+            </Markdown>
+          </Group>
+        )}
         </div>
       </MantineDropzone>
       <Center>

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -682,6 +682,9 @@ export default {
   "admin.config.legal.privacy-policy-url": "Privacy policy URL",
   "admin.config.legal.privacy-policy-url.description":
     "If you already have a privacy policy page you can link it here instead of using the text field.",
+  "admin.config.legal.company-sharing-policy": "Sharing policy ",
+  "admin.config.legal.company-sharing-policy.description": 
+    "A notice to be displayed to users on the upload page. This is to remind users what should and shouldn't be shared externally.",
 
   // 404
   "404.description": "Oops this page doesn't exist.",

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -74,6 +74,11 @@ export async function middleware(request: NextRequest) {
     ) {
       routes.disabled.routes.push("/privacy");
     }
+    if (
+      !getConfig("legal.companySharingPolicy")
+    ) {
+      routes.disabled.routes.push("/sharing_policy");
+    }
   }
 
   // prettier-ignore


### PR DESCRIPTION
Added a company sharing policy for issue #834.

A new company sharing policy can be made in the administrative interface. This will be shown in the middle of the dropzone component. Markdown is supported. 

My apologies, it's probably messy.  I haven't used any of these tools before. It's been a steep learning curve. 