### PR TITLE
Feature: Backend: Allow to define path to the config file

### DIFF
--- a/backend/src/config/config.service.ts
+++ b/backend/src/config/config.service.ts
@@ -13,6 +13,7 @@ import { PrismaService } from "src/prisma/prisma.service";
 import { stringToTimespan } from "src/utils/date.util";
 import { parse as yamlParse } from "yaml";
 import { YamlConfig } from "../../prisma/seed/config.seed";
+import { CONFIG_FILE } from "src/constants";
 
 /**
  * ConfigService extends EventEmitter to allow listening for config updates,
@@ -42,7 +43,7 @@ export class ConfigService extends EventEmitter {
   private async loadYamlConfig() {
     let configFile: string = "";
     try {
-      configFile = fs.readFileSync("../config.yaml", "utf8");
+      configFile = fs.readFileSync(CONFIG_FILE, "utf8");
     } catch (e) {
       this.logger.log(
         "Config.yaml is not set. Falling back to UI configuration.",

--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -1,5 +1,7 @@
 import { LogLevel } from "@nestjs/common";
 
+export const CONFIG_FILE = process.env.CONFIG_FILE || "../config.yaml";
+
 export const DATA_DIRECTORY = process.env.DATA_DIRECTORY || "./data";
 export const SHARE_DIRECTORY = `${DATA_DIRECTORY}/uploads/shares`;
 export const DATABASE_URL =

--- a/docs/docs/setup/configuration.md
+++ b/docs/docs/setup/configuration.md
@@ -33,6 +33,7 @@ For installation specific configuration, you can use environment variables. The 
 | `BACKEND_PORT`   | `8080`                                             | The port on which the backend listens.                                                                   |
 | `DATABASE_URL`   | `file:../data/pingvin-share.db?connection_limit=1` | The URL of the SQLite database.                                                                          |
 | `DATA_DIRECTORY` | `./data`                                           | The directory where data is stored.                                                                      |
+| `CONFIG_FILE`    | `../config.yaml`                                   | Path to the configuration file                                                                      |
 | `CLAMAV_HOST`    | `127.0.0.1` or `clamav` when running with Docker   | The IP address of the ClamAV server. See the [ClamAV docs](integrations.md#clamav) for more information. |
 | `CLAMAV_PORT`    | `3310`                                             | The port number of the ClamAV server.                                                                    |
 


### PR DESCRIPTION
## Issue

The path of the configuration file is currently hard coded to `../config.yaml` this work well when on the current docker image.
But this don't work if you want to store the configuration in an other location (in a read only folder or filesystem).

## PR

this PR allow to configure where the configuration file is located via the `CONFIG_FILE` environment variable.